### PR TITLE
Added Bazel rules for Maven deployment

### DIFF
--- a/dependencies/maven/rules.bzl
+++ b/dependencies/maven/rules.bzl
@@ -200,7 +200,7 @@ def _transitive_maven_dependencies(_target, ctx):
     return [TransitiveMavenInfo(transitive_dependencies = tags)]
 
 # Filled in by deployment_rules_builder
-_maven_packages = "common,server,console,protocol,client-java".split(",")
+_maven_packages = "java".split(",")
 _default_version_file = None if 'version_file_placeholder' in "//:VERSION" else "//:VERSION"
 _default_deployment_properties = None if 'deployment_properties_placeholder' in "//:deployment.properties" else "//:deployment.properties"
 

--- a/deployment.properties
+++ b/deployment.properties
@@ -23,6 +23,6 @@ maven.repository-url.release=http://maven.grakn.ai/nexus/content/repositories/re
 pip.repository-url.pypi=https://upload.pypi.org/legacy/
 pip.repository-url.test=https://test.pypi.org/legacy/
 npm.repository-url=https://registry.npmjs.org/
-maven.packages=common,server,console,protocol,client-java
+maven.packages=java
 rpm.repository-url.test=http://35.241.137.92/nexus/repository/temp/
 deb.repository-url.test=http://35.241.137.92/nexus/repository/apt-temp/

--- a/java/BUILD
+++ b/java/BUILD
@@ -19,6 +19,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+load("//dependencies/maven:rules.bzl", "deploy_maven_jar")
 
 java_library(
     name = "graql",
@@ -31,6 +32,13 @@ java_library(
         "//dependencies/maven/artifacts/org/antlr:antlr4-runtime", # sync version with @antlr4_runtime//jar
         "//dependencies/maven/artifacts/org/slf4j:slf4j-api",
     ],
+    tags = ["maven_coordinates=graql:lang:{pom_version}"],
+)
+
+deploy_maven_jar(
+  name = "deploy-maven-jar",
+  target = ":graql",
+  package = "java",
 )
 
 checkstyle_test(


### PR DESCRIPTION
## What is the goal of this PR?

We need to add the `deploy_maven_jar` bazel rule in order to create and deploy the maven Jar.

## What are the changes implemented in this PR?

1) Added the `deploy_maven_jar` to `//java/BUILD` file
2) Updated `deployment.properties` to register `//java:graql` as as a maven package