### PR TITLE
Improved Parser.parseQuery()

### DIFF
--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -22,9 +22,9 @@ grammar Graql;
 // Needed by Graql's Parser to ensure that it parses till end of string
 
 eof_query           :   query       EOF ;
-eof_query_list      :   query*      EOF ;
+eof_query_list      :   query+      EOF ;
 eof_pattern         :   pattern     EOF ;
-eof_pattern_list    :   pattern*    EOF ;
+eof_pattern_list    :   pattern+    EOF ;
 
 // GRAQL QUERY LANGUAGE ========================================================
 

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -74,26 +74,25 @@ import static java.util.stream.Collectors.toList;
  */
 public class Parser extends GraqlBaseVisitor {
 
-    private GraqlParser parse(String queryString, ErrorListener errorListener) {
-        CharStream charStream = CharStreams.fromString(queryString);
-
-        GraqlLexer lexer = new GraqlLexer(charStream);
-        lexer.removeErrorListeners();
-        lexer.addErrorListener(errorListener);
-        CommonTokenStream tokens = new CommonTokenStream(lexer);
-
-        GraqlParser parser = new GraqlParser(tokens);
-        parser.removeErrorListeners();
-        parser.addErrorListener(errorListener);
-
-        return parser;
-    }
-
     private <CONTEXT extends ParserRuleContext, RETURN> RETURN parseQuery(
             String queryString, Function<GraqlParser, CONTEXT> parserMethod, Function<CONTEXT, RETURN> visitor
     ) {
+        if (queryString == null || queryString.isEmpty()) {
+            throw GraqlException.create("Query String is NULL or Empty");
+        }
+
         ErrorListener errorListener = ErrorListener.of(queryString);
-        GraqlParser parser = parse(queryString, errorListener);
+        CharStream charStream = CharStreams.fromString(queryString);
+        GraqlLexer lexer = new GraqlLexer(charStream);
+
+        lexer.removeErrorListeners();
+        lexer.addErrorListener(errorListener);
+
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        GraqlParser parser = new GraqlParser(tokens);
+
+        parser.removeErrorListeners();
+        parser.addErrorListener(errorListener);
 
         // BailErrorStrategy + SLL is a very fast parsing strategy for queries
         // that are expected to be correct. However, it may not be able to

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -947,9 +947,9 @@ public class ParserTest {
     }
 
     @Test
-    public void testParseListEmpty() {
+    public void testParseEmptyString() {
         exception.expect(GraqlException.class);
-        List<GraqlQuery> queries = Graql.parseList("").collect(toList());
+        Graql.parse("");
     }
 
     @Test

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -948,8 +948,8 @@ public class ParserTest {
 
     @Test
     public void testParseListEmpty() {
+        exception.expect(GraqlException.class);
         List<GraqlQuery> queries = Graql.parseList("").collect(toList());
-        assertEquals(0, queries.size());
     }
 
     @Test


### PR DESCRIPTION
## What is the goal of this PR?

Improved `Parser.parseQuery()` core method to be simpler and check for nulls/empty, and updated Graql grammar to expect at least one query/pattern in `eof_query_list`/`eof_pattern_list`