### PR TITLE
GraqlGet subqueries enforces variables to within scope

### DIFF
--- a/java/exception/ErrorMessage.java
+++ b/java/exception/ErrorMessage.java
@@ -22,7 +22,7 @@ public enum ErrorMessage {
     SYNTAX_ERROR_NO_POINTER("syntax error at line %s:\n%s"),
     SYNTAX_ERROR("syntax error at line %s: \n%s\n%s\n%s"),
     CONFLICTING_PROPERTIES("the following unique properties in '%s' conflict: '%s' and '%s'"),
-    VARIABLE_OUT_OF_SCOPE("the variable %s is out of scope of the query"),
+    VARIABLE_OUT_OF_SCOPE("the variable [%s] is out of scope of the query"),
     NO_PATTERNS("no patterns have been provided. at least one pattern must be provided"),
     INVALID_COMPUTE_METHOD("Invalid compute method. The available compute methods are: [%s]."),
     INVALID_COMPUTE_CONDITION("Invalid condition(s) for 'compute [%s]'. The accepted condition(s) are: [%s]."),

--- a/java/query/GraqlGet.java
+++ b/java/query/GraqlGet.java
@@ -260,7 +260,7 @@ public class GraqlGet extends GraqlQuery implements Filterable, Aggregatable<Gra
             } else if (var != null && method.equals(Graql.Token.Aggregate.Method.COUNT)) {
                 throw new IllegalArgumentException("Aggregate COUNT does not accept a Variable");
             } else if (var != null && !query.vars().contains(var)) {
-                throw new IllegalArgumentException("Aggregate variable should be contained in GET query");
+                throw GraqlException.variableOutOfScope(var.toString());
             }
 
             this.var = var;
@@ -331,6 +331,8 @@ public class GraqlGet extends GraqlQuery implements Filterable, Aggregatable<Gra
 
             if (var == null) {
                 throw new NullPointerException("Variable is null");
+            } else if (!query.vars().contains(var)) {
+                throw GraqlException.variableOutOfScope(var.toString());
             }
             this.var = var;
         }
@@ -403,7 +405,7 @@ public class GraqlGet extends GraqlQuery implements Filterable, Aggregatable<Gra
                 } else if (var != null && this.method.equals(Graql.Token.Aggregate.Method.COUNT)) {
                     throw new IllegalArgumentException("Aggregate COUNT does not accept a Variable");
                 } else if (var != null && !group.query().vars().contains(var)) {
-                    throw new IllegalArgumentException("Aggregate variable should be contained in GET query");
+                    throw GraqlException.variableOutOfScope(var.toString());
                 }
                 this.var = var;
             }


### PR DESCRIPTION
## What is the goal of this PR?

`GraqlGet` subqueries enforce a validation check for variables to be within the scope of the query. And when validation not satisfied, it throws `GraqlException.variableNotInScope()` exception.