### PR TITLE
Rename 'relationship' to 'relation'

### DIFF
--- a/java/Graql.java
+++ b/java/Graql.java
@@ -682,7 +682,7 @@ public class Graql {
             PLAYS("plays"),
             REGEX("regex"),
             RELATES("relates"),
-            RELATION("relationship"), // TODO: Relationship syntax need to be updated
+            RELATION("relation"),
             SUB("sub"),
             SUBX("sub!"),
             THEN("then"),

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -524,14 +524,14 @@ public class ParserTest {
         String query = "define\n" +
                 "parent sub role;\n" +
                 "child sub role;\n" +
-                "parenthood sub relationship, relates parent, relates child;\n" +
+                "parenthood sub relation, relates parent, relates child;\n" +
                 "fatherhood sub parenthood, relates father as parent, relates son as child;";
         GraqlDefine parsed = Graql.parse(query).asDefine();
 
         GraqlDefine expected = define(
                 type("parent").sub("role"),
                 type("child").sub("role"),
-                type("parenthood").sub("relationship")
+                type("parenthood").sub("relation")
                         .relates(var().type("parent"))
                         .relates(var().type("child")),
                 type("fatherhood").sub("parenthood")
@@ -559,7 +559,7 @@ public class ParserTest {
     public void whenParsingDefineQuery_ResultIsSameAsJavaGraql() {
         String query = "define\n" +
                 "pokemon sub entity;\n" +
-                "evolution sub relationship;\n" +
+                "evolution sub relation;\n" +
                 "evolves-from sub role;\n" +
                 "evolves-to sub role;\n" +
                 "evolution relates evolves-from, relates evolves-to;\n" +
@@ -568,7 +568,7 @@ public class ParserTest {
 
         GraqlDefine expected = define(
                 type("pokemon").sub("entity"),
-                type("evolution").sub("relationship"),
+                type("evolution").sub("relation"),
                 type("evolves-from").sub("role"),
                 type("evolves-to").sub("role"),
                 type("evolution").relates("evolves-from").relates("evolves-to"),
@@ -582,7 +582,7 @@ public class ParserTest {
     public void whenParsingUndefineQuery_ResultIsSameAsJavaGraql() {
         String query = "undefine\n" +
                 "pokemon sub entity;\n" +
-                "evolution sub relationship;\n" +
+                "evolution sub relation;\n" +
                 "evolves-from sub role;\n" +
                 "evolves-to sub role;\n" +
                 "evolution relates evolves-from, relates evolves-to;\n" +
@@ -591,7 +591,7 @@ public class ParserTest {
 
         GraqlUndefine expected = undefine(
                 type("pokemon").sub("entity"),
-                type("evolution").sub("relationship"),
+                type("evolution").sub("relation"),
                 type("evolves-from").sub("role"),
                 type("evolves-to").sub("role"),
                 type("evolution").relates("evolves-from").relates("evolves-to"),
@@ -1049,7 +1049,7 @@ public class ParserTest {
     }
 
     @Test
-    public void whenParsingAQueryWithReifiedAttributeRelationshipSyntax_ItIsEquivalentToJavaGraql() {
+    public void whenParsingAQueryWithReifiedAttributeRelationSyntax_ItIsEquivalentToJavaGraql() {
         assertParseEquivalence("match $x has name $z via $x; get $x;");
     }
 

--- a/java/property/HasAttributeProperty.java
+++ b/java/property/HasAttributeProperty.java
@@ -29,33 +29,33 @@ import static java.util.stream.Collectors.joining;
 
 /**
  * Represents the {@code has} property on an Thing. This property can be queried, inserted or deleted.
- * The property is defined as a Relationship between an Thing and a Attribute,
+ * The property is defined as a Relation between an Thing and a Attribute,
  * where theAttribute is of a particular type. When matching,  Schema.EdgeLabel#ROLE_PLAYER
- * edges are used to speed up the traversal. The type of the Relationship does notmatter.
- * When inserting, an implicit Relationship is created between the instance and the Attribute,
+ * edges are used to speed up the traversal. The type of the Relation does not matter.
+ * When inserting, an implicit Relation is created between the instance and the Attribute,
  * using type labels derived from the label of the AttributeType.
  */
 public class HasAttributeProperty extends VarProperty {
 
     private final String type;
     private final Statement attribute;
-    private final Statement relationship;
+    private final Statement relation;
 
     public HasAttributeProperty(String type, Statement attribute) {
         this(type, attribute, new Statement(new Variable()));
     }
 
-    public HasAttributeProperty(String type, Statement attribute, Statement relationship) {
+    public HasAttributeProperty(String type, Statement attribute, Statement relation) {
         attribute = attribute.isa(Graql.type(type));
         if (type == null) {
             throw new NullPointerException("Null type");
         }
         this.type = type;
         this.attribute = attribute;
-        if (relationship == null) {
-            throw new NullPointerException("Null relationship");
+        if (relation == null) {
+            throw new NullPointerException("Null relation");
         }
-        this.relationship = relationship;
+        this.relation = relation;
     }
 
     public String type() {
@@ -66,8 +66,8 @@ public class HasAttributeProperty extends VarProperty {
         return attribute;
     }
 
-    public Statement relationship() {
-        return relationship;
+    public Statement relation() {
+        return relation;
     }
 
     @Override
@@ -87,8 +87,8 @@ public class HasAttributeProperty extends VarProperty {
             attribute().getProperties(ValueProperty.class).forEach(prop -> property.add(prop.operation().toString()));
         }
 
-        if (hasReifiedRelationship()) {
-            property.add(Graql.Token.Property.VIA.toString()).add(relationship().getPrintableName());
+        if (hasReifiedRelation()) {
+            property.add(Graql.Token.Property.VIA.toString()).add(relation().getPrintableName());
         }
 
         return property.build().collect(joining(Graql.Token.Char.SPACE.toString()));
@@ -106,7 +106,7 @@ public class HasAttributeProperty extends VarProperty {
 
     @Override
     public Stream<Statement> statements() {
-        return Stream.of(attribute(), relationship());
+        return Stream.of(attribute(), relation());
     }
 
     @Override
@@ -114,8 +114,8 @@ public class HasAttributeProperty extends VarProperty {
         return StatementInstance.class;
     }
 
-    private boolean hasReifiedRelationship() {
-        return relationship().properties().stream().findAny().isPresent() || relationship().var().isUserDefinedName();
+    private boolean hasReifiedRelation() {
+        return relation().properties().stream().findAny().isPresent() || relation().var().isUserDefinedName();
     }
 
     @Override
@@ -132,7 +132,7 @@ public class HasAttributeProperty extends VarProperty {
         // This check is necessary for `equals` and `hashCode` because `Statement` equality is defined
         // s.t. `var() != var()`, but `var().label("movie") == var().label("movie")`
         // i.e., a `Var` is compared by name, but a `Statement` ignores the name if the var is not user-defined
-        return !hasReifiedRelationship() || relationship().equals(that.relationship());
+        return !hasReifiedRelation() || relation().equals(that.relation());
     }
 
     @Override
@@ -141,8 +141,8 @@ public class HasAttributeProperty extends VarProperty {
         result = 31 * result + attribute().hashCode();
 
         // TODO: Having to check this is pretty dodgy, explanation in #equals
-        if (hasReifiedRelationship()) {
-            result = 31 * result + relationship().hashCode();
+        if (hasReifiedRelation()) {
+            result = 31 * result + relation().hashCode();
         }
 
         return result;

--- a/java/property/HasAttributeTypeProperty.java
+++ b/java/property/HasAttributeTypeProperty.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
  * This property can be queried or inserted. Whether this is a key is indicated by the
  * HasAttributeTypeProperty#isKey field.
  * This property is defined as an implicit ontological structure between a Type and a AttributeType,
- * including one implicit RelationshipType and two implicit Roles. The labels of these types are derived
+ * including one implicit RelationType and two implicit Roles. The labels of these types are derived
  * from the label of the AttributeType.
  * Like HasAttributeProperty, if this is not a key and is used in a match clause it will not use the implicit
  * structure - instead, it will match if there is any kind of relation type connecting the two types.

--- a/java/property/IsaProperty.java
+++ b/java/property/IsaProperty.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
 /**
  * Represents the {@code isa} property on a Thing.
  * This property can be queried and inserted.
- * THe property is defined as a relationship between an Thing and a Type.
+ * THe property is defined as a relation between an Thing and a Type.
  * When matching, any subtyping is respected. For example, if we have {@code $bob isa man}, {@code man sub person},
  * {@code person sub entity} then it follows that {@code $bob isa person} and {@code bob isa entity}.
  */

--- a/java/property/RelatesProperty.java
+++ b/java/property/RelatesProperty.java
@@ -27,10 +27,10 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 /**
- * Represents the {@code relates} property on a RelationshipType.
+ * Represents the {@code relates} property on a RelationType.
  * This property can be queried, inserted or deleted.
- * This property relates a RelationshipType and a Role. It indicates that a Relationship whose
- * type is this RelationshipType may have a role-player playing the given Role.
+ * This property relates a RelationType and a Role. It indicates that a Relation whose
+ * type is this RelationType may have a role-player playing the given Role.
  */
 public class RelatesProperty extends VarProperty {
 

--- a/java/property/RelationProperty.java
+++ b/java/property/RelationProperty.java
@@ -32,7 +32,7 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.joining;
 
 /**
- * Represents the relation property (e.g. {@code ($x, $y)} or {@code (wife: $x, husband: $y)}) on a relationship.
+ * Represents the relation property (e.g. {@code ($x, $y)} or {@code (wife: $x, husband: $y)}) on a relation.
  * This property can be queried and inserted.
  * This propert is comprised of instances of RolePlayer, which represents associations between a
  * role-player Thing and an optional Role.


### PR DESCRIPTION
## What is the goal of this PR?

The term _"relationship"_ is a very frequently used term, and first-class citizen in our schema and query language. Yet it's too long and it could be shorter: _"relation"_.

## What are the changes implemented in this PR?

Rename the term _"relationship"_ to _"relation"_.