### PR TITLE
Introducing 'native types' in Graql grammar and tokens

### DIFF
--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -240,7 +240,7 @@ DEFINE          : 'define'      ;   UNDEFINE        : 'undefine'    ;
 INSERT          : 'insert'      ;   DELETE          : 'delete'      ;
 AGGREGATE       : 'aggregate'   ;   COMPUTE         : 'compute'     ;
 
-// TYPE KEYWORDS
+// NATIVE TYPE KEYWORDS
 
 THING           : 'thing'       ;   ENTITY          : 'entity'      ;
 ATTRIBUTE       : 'attribute'   ;   RELATION        : 'relation'    ;

--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -207,13 +207,15 @@ compute_arg         :   MIN_K     '=' INTEGER_                                  
 type                :   label | VAR_ ;                                          // A type can be a label or variable
 types               :   label | label_array ;
 label_array         :   '[' label ( ',' label )* ']' ;
-label               :   identifier | ID_IMPLICIT_;
+label               :   type_native | identifier | ID_IMPLICIT_;
 
 id                  :   identifier ;
 identifier          :   ID_ | STRING_ | unreserved ;                            // TODO: disallow quoted strings as IDs
 
 // LITERAL INPUT VALUES =======================================================
 
+type_native         :   THING       |   ENTITY      |   ATTRIBUTE
+                    |   RELATION    |   ROLE        |   RULE        ;
 datatype            :   LONG        |   DOUBLE      |   STRING
                     |   BOOLEAN     |   DATE        ;
 literal             :   STRING_     |   INTEGER_    |   REAL_
@@ -238,10 +240,16 @@ DEFINE          : 'define'      ;   UNDEFINE        : 'undefine'    ;
 INSERT          : 'insert'      ;   DELETE          : 'delete'      ;
 AGGREGATE       : 'aggregate'   ;   COMPUTE         : 'compute'     ;
 
+// TYPE KEYWORDS
+
+THING           : 'thing'       ;   ENTITY          : 'entity'      ;
+ATTRIBUTE       : 'attribute'   ;   RELATION        : 'relation'    ;
+ROLE            : 'role'        ;   RULE            : 'rule'        ;
+
 // DELETE AND GET QUERY MODIFIER KEYWORDS
 
 OFFSET          : 'offset'      ;   LIMIT           : 'limit'       ;
-SORT            : 'sort'        ;   ORDER_           : ASC | DESC    ;
+SORT            : 'sort'        ;   ORDER_          : ASC | DESC    ;
 ASC             : 'asc'         ;   DESC            : 'desc'        ;
 
 // STATEMENT PROPERTY KEYWORDS

--- a/java/Graql.java
+++ b/java/Graql.java
@@ -513,6 +513,35 @@ public class Graql {
 
     public static class Token {
 
+        public enum Type {
+            THING("thing"),
+            ENTITY("entity"),
+            ATTRIBUTE("attribute"),
+            RELATION("relation"),
+            ROLE("role"),
+            RULE("rule");
+
+            private final String type;
+
+            Type(String type) {
+                this.type = type;
+            }
+
+            @Override
+            public String toString() {
+                return this.type;
+            }
+
+            public static Type of(String value) {
+                for (Type c : Type.values()) {
+                    if (c.type.equals(value)) {
+                        return c;
+                    }
+                }
+                return null;
+            }
+        }
+
         /**
          * Graql commands to determine the type of query
          */
@@ -682,7 +711,6 @@ public class Graql {
             PLAYS("plays"),
             REGEX("regex"),
             RELATES("relates"),
-            RELATION("relation"),
             SUB("sub"),
             SUBX("sub!"),
             THEN("then"),

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -847,7 +847,9 @@ public class Parser extends GraqlBaseVisitor {
 
     @Override
     public String visitLabel(GraqlParser.LabelContext ctx) {
-        if (ctx.identifier() != null) {
+        if (ctx.type_native() != null) {
+            return ctx.type_native().getText();
+        } else if (ctx.identifier() != null) {
             return visitIdentifier(ctx.identifier());
         } else {
             return ctx.ID_IMPLICIT_().getText();

--- a/java/property/RelationProperty.java
+++ b/java/property/RelationProperty.java
@@ -54,7 +54,7 @@ public class RelationProperty extends VarProperty {
 
     @Override
     public String keyword() {
-        return Graql.Token.Property.RELATION.toString();
+        return Graql.Token.Type.RELATION.toString(); // TODO: figure out a way to not use this
     }
 
     public String property() {

--- a/java/util/StringUtil.java
+++ b/java/util/StringUtil.java
@@ -19,6 +19,7 @@
 package graql.lang.util;
 
 import graql.grammar.GraqlLexer;
+import graql.lang.Graql;
 import org.apache.commons.lang.StringEscapeUtils;
 
 import java.text.DecimalFormat;
@@ -65,7 +66,7 @@ public class StringUtil {
     public static String escapeLabelOrId(String value) {
         // TODO: This regex should be saved in Query class once it is moved to //graql package
         if (value.matches("^@?[a-zA-Z_][a-zA-Z0-9_-]*$") &&
-                (!GRAQL_KEYWORDS.contains(value)) || ALLOWED_ID_KEYWORDS.contains(value)) {
+                (Graql.Token.Type.of(value) != null || ALLOWED_ID_KEYWORDS.contains(value) || !GRAQL_KEYWORDS.contains(value)) ) {
             return value;
         } else {
             return quoteString(value);


### PR DESCRIPTION
## What is the goal of this PR?

1) Graql did not restrict the use of "native types" (such as "entity", "relation", "attribute", "thing", "role" and "rule") at syntax parsing. It should.
2) There is currently no way for Graql users to easily refer to "native types" when constructing their Graql queries. In `graknlabs/grakn`, the query construction utilises `Schema.MetaSchema` enum, which contains the "meta types" in Grakn (which are the same as Graql "native types"), however, `Schema` is a low-level class that is used for the construction of the underlying binary graph. This access is inappropriate because it requires a dependency to a lower-level underlying class merely for constructing a query (which is a high-level user task), for example: `match $x isa ` + `Schema.MetaSchema.THING`.

## What are the changes implemented in this PR?

1) We extend `label` to include `type_native`, which is defined as the following:
```
label           :   type_native | identifier    |   ID_IMPLICIT_;
type_native     :   THING       |   ENTITY      |   ATTRIBUTE
                |   RELATION    |   ROLE        |   RULE        ;

// NATIVE TYPE KEYWORDS

THING           : 'thing'       ;   ENTITY          : 'entity'      ;
ATTRIBUTE       : 'attribute'   ;   RELATION        : 'relation'    ;
ROLE            : 'role'        ;   RULE            : 'rule'        ;
```

2) We introduce `Graql.Token.Type` enum, which contains all the above native types.