### PR TITLE
Overloaded Statement.sub() and .isa() to accept Graql.Token.Type

### DIFF
--- a/java/statement/builder/StatementInstanceBuilder.java
+++ b/java/statement/builder/StatementInstanceBuilder.java
@@ -31,6 +31,11 @@ import java.time.LocalDateTime;
 public interface StatementInstanceBuilder {
 
     @CheckReturnValue
+    default StatementInstance isa(Graql.Token.Type type) {
+        return isa(type.toString());
+    }
+
+    @CheckReturnValue
     default StatementInstance isa(String type) {
         return isa(Graql.type(type));
     }
@@ -38,6 +43,11 @@ public interface StatementInstanceBuilder {
     @CheckReturnValue
     default StatementInstance isa(Statement type) {
         return isa(new IsaProperty(type));
+    }
+
+    @CheckReturnValue
+    default StatementInstance isaX(Graql.Token.Type type) {
+        return isa(type.toString());
     }
 
     @CheckReturnValue

--- a/java/statement/builder/StatementTypeBuilder.java
+++ b/java/statement/builder/StatementTypeBuilder.java
@@ -61,6 +61,10 @@ public interface StatementTypeBuilder {
         return type(AbstractProperty.get());
     }
 
+    default StatementType sub(Graql.Token.Type type) {
+        return sub(type.toString());
+    }
+
     /**
      * @param type a concept type id that this variable must be a kind of
      * @return this
@@ -77,6 +81,10 @@ public interface StatementTypeBuilder {
     @CheckReturnValue
     default StatementType sub(Statement type) {
         return sub(new SubProperty(type));
+    }
+
+    default StatementType subX(Graql.Token.Type type) {
+        return subX(type.toString());
     }
 
     /**


### PR DESCRIPTION
## What is the goal of this PR?

Following PR #17, we want to also enable `.sub()` and `.isa()` methods on Graql `Statement`s to accept `Graql.Token.Type`