### PR TITLE
Overloaded Statement.type() to accept Graql.Token.Type

### DIFF
--- a/java/statement/builder/StatementTypeBuilder.java
+++ b/java/statement/builder/StatementTypeBuilder.java
@@ -42,6 +42,11 @@ import javax.annotation.Nullable;
  */
 public interface StatementTypeBuilder {
 
+    @CheckReturnValue
+    default StatementType type(Graql.Token.Type type) {
+        return type(type.toString());
+    }
+    
     /**
      * @param name a string that this variable's label must match
      * @return this


### PR DESCRIPTION
## What is the goal of this PR?

Following PR #17, we want to also enable `.type()` method on Graql `Statement`s to accept `Graql.Token.Type`