### PR TITLE
Overloaded Graql.type() to accept Graql.Token.Type

### DIFF
--- a/java/Graql.java
+++ b/java/Graql.java
@@ -247,10 +247,11 @@ public class Graql {
         return var(new Variable(false));
     }
 
-    /**
-     * @param label the label of a concept
-     * @return a variable pattern that identifies a concept by label
-     */
+    @CheckReturnValue
+    public static StatementType type(Graql.Token.Type type) {
+        return type(type.toString());
+    }
+
     @CheckReturnValue
     public static StatementType type(String label) {
         return hiddenVar().type(label);


### PR DESCRIPTION
## What is the goal of this PR?

Following PR #17, we want to also enable `.type()` method on main `Graql` class to accept `Graql.Token.Type`