### PR TITLE
Ignore null in Graql Aggregate Hashcode

### DIFF
--- a/java/query/GraqlGet.java
+++ b/java/query/GraqlGet.java
@@ -459,7 +459,9 @@ public class GraqlGet extends GraqlQuery implements Filterable, Aggregatable<Gra
                 h *= 1000003;
                 h ^= this.method.hashCode();
                 h *= 1000003;
-                h ^= this.var.hashCode();
+                if (this.var != null) {
+                    h ^= this.var.hashCode();
+                }
                 return h;
             }
         }


### PR DESCRIPTION
## What is the goal of this PR?
Fix null pointer error when trying to hash the GraqlGet - Aggregate subtype.

## What are the changes implemented in this PR?
Ignore the `var` field if it is null