### PR TITLE
Rename to asRetrievedVar() and isRetrieved

### DIFF
--- a/java/property/HasAttributeProperty.java
+++ b/java/property/HasAttributeProperty.java
@@ -81,7 +81,7 @@ public class HasAttributeProperty extends VarProperty {
 
         property.add(type);
 
-        if (attribute().var().isUserDefinedName()) {
+        if (attribute().var().isRetrieved()) {
             property.add(attribute().var().toString());
         } else {
             attribute().getProperties(ValueProperty.class).forEach(prop -> property.add(prop.operation().toString()));
@@ -115,7 +115,7 @@ public class HasAttributeProperty extends VarProperty {
     }
 
     private boolean hasReifiedRelation() {
-        return relation().properties().stream().findAny().isPresent() || relation().var().isUserDefinedName();
+        return relation().properties().stream().findAny().isPresent() || relation().var().isRetrieved();
     }
 
     @Override

--- a/java/property/HasAttributeProperty.java
+++ b/java/property/HasAttributeProperty.java
@@ -81,7 +81,7 @@ public class HasAttributeProperty extends VarProperty {
 
         property.add(type);
 
-        if (attribute().var().isRetrieved()) {
+        if (attribute().var().isReturned()) {
             property.add(attribute().var().toString());
         } else {
             attribute().getProperties(ValueProperty.class).forEach(prop -> property.add(prop.operation().toString()));
@@ -115,7 +115,7 @@ public class HasAttributeProperty extends VarProperty {
     }
 
     private boolean hasReifiedRelation() {
-        return relation().properties().stream().findAny().isPresent() || relation().var().isRetrieved();
+        return relation().properties().stream().findAny().isPresent() || relation().var().isReturned();
     }
 
     @Override

--- a/java/statement/Statement.java
+++ b/java/statement/Statement.java
@@ -264,7 +264,7 @@ public class Statement implements Pattern,
     @Override
     public Set<Variable> variables() {
         return innerStatements().stream().map(Statement::var)
-                .filter(Variable::isUserDefinedName)
+                .filter(Variable::isRetrieved)
                 .collect(toSet());
     }
 
@@ -312,13 +312,13 @@ public class Statement implements Pattern,
 
         Statement other = (Statement) o;
 
-        if (var().isUserDefinedName() != other.var().isUserDefinedName()) return false;
+        if (var().isRetrieved() != other.var().isRetrieved()) return false;
 
         // "simplifying" this makes it harder to read
         //noinspection SimplifiableIfStatement
         if (!properties().equals(other.properties())) return false;
 
-        return !var().isUserDefinedName() || var().equals(other.var());
+        return !var().isRetrieved() || var().equals(other.var());
 
     }
 
@@ -327,8 +327,8 @@ public class Statement implements Pattern,
         if (hashCode == 0) {
             // This hashCode implementation is special: it considers all non-user-defined vars as equivalent
             hashCode = properties().hashCode();
-            if (var().isUserDefinedName()) hashCode = 31 * hashCode + var().hashCode();
-            hashCode = 31 * hashCode + (var().isUserDefinedName() ? 1 : 0);
+            if (var().isRetrieved()) hashCode = 31 * hashCode + var().hashCode();
+            hashCode = 31 * hashCode + (var().isRetrieved() ? 1 : 0);
         }
         return hashCode;
     }

--- a/java/statement/Statement.java
+++ b/java/statement/Statement.java
@@ -264,7 +264,7 @@ public class Statement implements Pattern,
     @Override
     public Set<Variable> variables() {
         return innerStatements().stream().map(Statement::var)
-                .filter(Variable::isRetrieved)
+                .filter(Variable::isReturned)
                 .collect(toSet());
     }
 
@@ -312,13 +312,13 @@ public class Statement implements Pattern,
 
         Statement other = (Statement) o;
 
-        if (var().isRetrieved() != other.var().isRetrieved()) return false;
+        if (var().isReturned() != other.var().isReturned()) return false;
 
         // "simplifying" this makes it harder to read
         //noinspection SimplifiableIfStatement
         if (!properties().equals(other.properties())) return false;
 
-        return !var().isRetrieved() || var().equals(other.var());
+        return !var().isReturned() || var().equals(other.var());
 
     }
 
@@ -327,8 +327,8 @@ public class Statement implements Pattern,
         if (hashCode == 0) {
             // This hashCode implementation is special: it considers all non-user-defined vars as equivalent
             hashCode = properties().hashCode();
-            if (var().isRetrieved()) hashCode = 31 * hashCode + var().hashCode();
-            hashCode = 31 * hashCode + (var().isRetrieved() ? 1 : 0);
+            if (var().isReturned()) hashCode = 31 * hashCode + var().hashCode();
+            hashCode = 31 * hashCode + (var().isReturned() ? 1 : 0);
         }
         return hashCode;
     }

--- a/java/statement/Variable.java
+++ b/java/statement/Variable.java
@@ -89,7 +89,7 @@ public class Variable {
      *
      * @return whether the variable has been manually defined or automatically generated.
      */
-    public boolean isUserDefinedName() {
+    public boolean isRetrieved() {
         return type() == Type.NAMED;
     }
 
@@ -99,8 +99,8 @@ public class Variable {
      *
      * @return a new variable with the same symbol as the previous, but set as user-defined.
      */
-    public Variable asUserDefined() {
-        if (isUserDefinedName()) {
+    public Variable asRetrievedVar() {
+        if (isRetrieved()) {
             return this;
         } else {
             return new Variable(name(), Type.NAMED);
@@ -123,7 +123,7 @@ public class Variable {
 
     @Override
     public String toString() {
-        if (isUserDefinedName()) {
+        if (isRetrieved()) {
             return Graql.Token.Char.$ + name();
         } else {
             return Graql.Token.Char.$_.toString();

--- a/java/statement/Variable.java
+++ b/java/statement/Variable.java
@@ -89,7 +89,7 @@ public class Variable {
      *
      * @return whether the variable has been manually defined or automatically generated.
      */
-    public boolean isRetrieved() {
+    public boolean isReturned() {
         return type() == Type.NAMED;
     }
 
@@ -99,8 +99,8 @@ public class Variable {
      *
      * @return a new variable with the same symbol as the previous, but set as user-defined.
      */
-    public Variable asRetrievedVar() {
-        if (isRetrieved()) {
+    public Variable asReturnedVar() {
+        if (isReturned()) {
             return this;
         } else {
             return new Variable(name(), Type.NAMED);
@@ -123,7 +123,7 @@ public class Variable {
 
     @Override
     public String toString() {
-        if (isRetrieved()) {
+        if (isReturned()) {
             return Graql.Token.Char.$ + name();
         } else {
             return Graql.Token.Char.$_.toString();


### PR DESCRIPTION
## What is the goal of this PR?
Clearer naming when indicating a variable is to be returned as part of the `get` clause. This is because in many places `asUserDefined` is not actually a user defined variable (especially in reasoner and QP) but instead used to ensure the variable is part of the `get` clause. This has lead to confusion about whether it's really about being able to check whether a variable was originally created by the user, or whether it's means to be returned in the `get`. The two main known use cases are:
1. Users creating variables with `var()`, then setting `asUserDefined()` to avoid creating a name for a variable they want to see in the `get()`
2. Internally, explicitly wanting to have the variable be returned.
Both boil down to creating anonymous variables that should be returned.

## What are the changes implemented in this PR?
Rename `asUserDefined()` to `asReturnedVar()` and `isUserDefinedName()` to `isReturned()`. This closes #53.