### PR TITLE
Extended label lexer

### DIFF
--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -321,7 +321,7 @@ ID_IMPLICIT_    : '@' NameChar+ ;
 fragment NameChar : NameStartChar
    | '0'..'9'
    | '_'
-   | '_'
+   | '-'
    | '\u00B7'
    | '\u0300'..'\u036F'
    | '\u203F'..'\u2040';

--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -314,13 +314,13 @@ DATETIME_       : DATE_FRAGMENT_ 'T' TIME_              ;
 VAR_            : VAR_ANONYMOUS_ | VAR_NAMED_ ;
 VAR_ANONYMOUS_  : '$_' ;
 VAR_NAMED_      : '$' [a-zA-Z0-9_-]* ;
-//ID_             : [a-zA-Z_] [a-zA-Z0-9_-]* ;
 ID_             : NameStartChar NameChar* ;
-ID_IMPLICIT_    : '@' [a-zA-Z0-9_-]+ ;
+ID_IMPLICIT_    : '@' NameChar+ ;
 
 
 fragment NameChar : NameStartChar
    | '0'..'9'
+   | '_'
    | '_'
    | '\u00B7'
    | '\u0300'..'\u036F'

--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -314,8 +314,32 @@ DATETIME_       : DATE_FRAGMENT_ 'T' TIME_              ;
 VAR_            : VAR_ANONYMOUS_ | VAR_NAMED_ ;
 VAR_ANONYMOUS_  : '$_' ;
 VAR_NAMED_      : '$' [a-zA-Z0-9_-]* ;
-ID_             : [a-zA-Z_] [a-zA-Z0-9_-]* ;
+//ID_             : [a-zA-Z_] [a-zA-Z0-9_-]* ;
+ID_             : NameStartChar NameChar* ;
 ID_IMPLICIT_    : '@' [a-zA-Z0-9_-]+ ;
+
+
+fragment NameChar : NameStartChar
+   | '0'..'9'
+   | '_'
+   | '\u00B7'
+   | '\u0300'..'\u036F'
+   | '\u203F'..'\u2040';
+fragment NameStartChar : 'A'..'Z' | 'a'..'z'
+   | '\u00C0'..'\u00D6'
+   | '\u00D8'..'\u00F6'
+   | '\u00F8'..'\u02FF'
+   | '\u0370'..'\u037D'
+   | '\u037F'..'\u1FFF'
+   | '\u200C'..'\u200D'
+   | '\u2070'..'\u218F'
+   | '\u2C00'..'\u2FEF'
+   | '\u3001'..'\uD7FF'
+   | '\uF900'..'\uFDCF'
+   | '\uFDF0'..'\uFFFD';
+
+
+
 
 // FRAGMENTS OF KEYWORDS =======================================================
 

--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -314,29 +314,32 @@ DATETIME_       : DATE_FRAGMENT_ 'T' TIME_              ;
 VAR_            : VAR_ANONYMOUS_ | VAR_NAMED_ ;
 VAR_ANONYMOUS_  : '$_' ;
 VAR_NAMED_      : '$' [a-zA-Z0-9_-]* ;
-ID_             : NameStartChar NameChar* ;
-ID_IMPLICIT_    : '@' NameChar+ ;
+ID_             : LABEL_START_CHAR LABEL_CHAR* ;
+ID_IMPLICIT_    : '@' LABEL_CHAR+ ;
 
 
-fragment NameChar : NameStartChar
-   | '0'..'9'
-   | '_'
-   | '-'
-   | '\u00B7'
-   | '\u0300'..'\u036F'
-   | '\u203F'..'\u2040';
-fragment NameStartChar : 'A'..'Z' | 'a'..'z'
-   | '\u00C0'..'\u00D6'
-   | '\u00D8'..'\u00F6'
-   | '\u00F8'..'\u02FF'
-   | '\u0370'..'\u037D'
-   | '\u037F'..'\u1FFF'
-   | '\u200C'..'\u200D'
-   | '\u2070'..'\u218F'
-   | '\u2C00'..'\u2FEF'
-   | '\u3001'..'\uD7FF'
-   | '\uF900'..'\uFDCF'
-   | '\uFDF0'..'\uFFFD';
+
+// LABEL NAME FRAGMENTS
+fragment LABEL_START_CHAR : 'A'..'Z' | 'a'..'z'
+                       | '\u00C0'..'\u00D6'
+                       | '\u00D8'..'\u00F6'
+                       | '\u00F8'..'\u02FF'
+                       | '\u0370'..'\u037D'
+                       | '\u037F'..'\u1FFF'
+                       | '\u200C'..'\u200D'
+                       | '\u2070'..'\u218F'
+                       | '\u2C00'..'\u2FEF'
+                       | '\u3001'..'\uD7FF'
+                       | '\uF900'..'\uFDCF'
+                       | '\uFDF0'..'\uFFFD';
+
+fragment LABEL_CHAR : LABEL_START_CHAR
+                  | '0'..'9'
+                  | '_'
+                  | '-'
+                  | '\u00B7'
+                  | '\u0300'..'\u036F'
+                  | '\u203F'..'\u2040';
 
 
 


### PR DESCRIPTION
## What is the goal of this PR?
Multiple community members and clients have asked for UTF-8 support in labels. Before this PR, we only support data instances having special characters (eg. attributes of `string` datatype), but we encountered errors when definining schema types with these characters, such as those documented in https://github.com/graknlabs/graql/issues/58 : `define Kläger sub entity;` fails.

An investigation revealed that this was perfectly definable using the direct methods on `Transaction`, so it is the Antlr grammar that fails to parse the extended character sets. This PR extends the allowed characters in the labels and implicit labels. To do this we borrow the regex for these valid variable names from Antlr's _internal_ allowed grammar (https://github.com/antlr/antlr4/blob/master/doc/lexicon.md).

## What are the changes implemented in this PR?
Borrow Antrl's internal lexer rules for valid variables names to extend Graql's allowed label range beyond ASCII.