### PR TITLE
Restrict the token patterns for type labels and ID values

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ jobs:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
+          bazel run //grammar:deploy-maven -- snapshot $CIRCLE_SHA1
           bazel run //java:deploy-maven -- snapshot $CIRCLE_SHA1
 
   test-deployment-maven:
@@ -101,6 +102,7 @@ jobs:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
+          bazel run //grammar:deploy-maven -- snapshot $(cat VERSION)
           bazel run //java:deploy-maven -- release $(cat VERSION)
 
   release-cleanup:

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,5 +22,5 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "d2be22150c8ca386162e0c49d3f82785a11e8d98", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "56f792ce5d0edd007c28d202d348057dfe6e795c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )

--- a/grammar/BUILD
+++ b/grammar/BUILD
@@ -19,11 +19,34 @@
 package(default_visibility = ["//:__subpackages__"])
 
 load("@rules_antlr//antlr:antlr4.bzl", "antlr4")
+load("@graknlabs_build_tools//distribution/maven:rules.bzl", "assemble_maven", "deploy_maven")
 
 antlr4(
-    name = "graql-java",
-    srcs = glob(["**/*.g4"]),
+    name = "java-src",
+    srcs = glob(["*.g4"]),
     language = "Java",
     visitor = True,
     package = "graql.grammar",
+)
+
+java_library(
+    name = "java",
+    srcs = [":java-src"],
+    deps = [
+        "//dependencies/maven/artifacts/org/antlr:antlr4-runtime", # sync version with @antlr4_runtime//jar
+    ],
+    tags = ["maven_coordinates=io.graql:grammar:{pom_version}"],
+)
+
+assemble_maven(
+  name = "assemble-maven",
+  target = ":java",
+  package = "grammar",
+  version_file = "//:VERSION",
+  workspace_refs = "@graknlabs_graql_workspace_refs//:refs.json"
+)
+
+deploy_maven(
+    name = "deploy-maven",
+    target = ":assemble-maven",
 )

--- a/grammar/BUILD
+++ b/grammar/BUILD
@@ -18,8 +18,8 @@
 
 package(default_visibility = ["//:__subpackages__"])
 
-load("@rules_antlr//antlr:antlr4.bzl", "antlr4")
 load("@graknlabs_build_tools//distribution/maven:rules.bzl", "assemble_maven", "deploy_maven")
+load("@rules_antlr//antlr:antlr4.bzl", "antlr4")
 
 antlr4(
     name = "java-src",
@@ -35,7 +35,7 @@ java_library(
     deps = [
         "//dependencies/maven/artifacts/org/antlr:antlr4-runtime", # sync version with @antlr4_runtime//jar
     ],
-    tags = ["maven_coordinates=io.graql:grammar:{pom_version}"],
+    tags = ["maven_coordinates=io.graql:grammar:{pom_version}", "checkstyle_ignore"],
 )
 
 assemble_maven(

--- a/java/BUILD
+++ b/java/BUILD
@@ -24,8 +24,9 @@ load("@graknlabs_bazel_distribution//github:rules.bzl", "deploy_github")
 
 java_library(
     name = "graql",
-    srcs = ["//grammar:graql-java"] + glob(["**/*.java"], exclude = ["**/test/**"]),
+    srcs = glob(["**/*.java"], exclude = ["**/test/**"]),
     deps = [
+        "//grammar:java",
         # External dependencies
         "//dependencies/maven/artifacts/com/google/guava:guava",
         "//dependencies/maven/artifacts/com/google/code/findbugs:jsr305",

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -864,12 +864,12 @@ public class ParserTest {
 
     @Test
     public void testParseComputePath() {
-        assertParseEquivalence("compute path from \"1\", to \"2\", in person;");
+        assertParseEquivalence("compute path from V1, to V2, in person;");
     }
 
     @Test
     public void testParseComputePathWithMultipleInTypes() {
-        assertParseEquivalence("compute path from \"1\", to \"2\", in [person, marriage];");
+        assertParseEquivalence("compute path from V1, to V2, in [person, marriage];");
     }
 
     @Test

--- a/java/property/TypeProperty.java
+++ b/java/property/TypeProperty.java
@@ -20,7 +20,6 @@ package graql.lang.property;
 
 import graql.lang.Graql;
 import graql.lang.statement.StatementType;
-import graql.lang.util.StringUtil;
 
 /**
  * Represents the {@code label} property on a Type.
@@ -49,7 +48,7 @@ public class TypeProperty extends VarProperty {
 
     @Override
     public String property() {
-        return StringUtil.escapeLabelOrId(name());
+        return name();
     }
 
     @Override

--- a/java/query/GraqlCompute.java
+++ b/java/query/GraqlCompute.java
@@ -21,7 +21,6 @@ package graql.lang.query;
 import graql.lang.Graql;
 import graql.lang.exception.GraqlException;
 import graql.lang.query.builder.Computable;
-import graql.lang.util.StringUtil;
 
 import javax.annotation.CheckReturnValue;
 import java.util.ArrayList;
@@ -38,7 +37,6 @@ import java.util.function.Supplier;
 import static graql.lang.util.Collections.map;
 import static graql.lang.util.Collections.set;
 import static graql.lang.util.Collections.tuple;
-import static graql.lang.util.StringUtil.escapeLabelOrId;
 import static java.util.stream.Collectors.joining;
 
 
@@ -131,12 +129,10 @@ public abstract class GraqlCompute extends GraqlQuery implements Computable {
 
         if (!types.isEmpty()) {
             if (types.size() == 1) {
-                inTypesString.append(escapeLabelOrId(types.iterator().next()));
+                inTypesString.append(types.iterator().next());
             } else {
                 inTypesString.append(Graql.Token.Char.SQUARE_OPEN);
-                inTypesString.append(inTypes.stream()
-                                             .map(StringUtil::escapeLabelOrId)
-                                             .collect(joining(Graql.Token.Char.COMMA_SPACE.toString())));
+                inTypesString.append(inTypes.stream().collect(joining(Graql.Token.Char.COMMA_SPACE.toString())));
                 inTypesString.append(Graql.Token.Char.SQUARE_CLOSE);
             }
         }

--- a/java/query/GraqlCompute.java
+++ b/java/query/GraqlCompute.java
@@ -104,8 +104,8 @@ public abstract class GraqlCompute extends GraqlQuery implements Computable {
         // Because, we want to know the user provided conditions, rather than the default conditions from the getters.
         // The exception is for arguments. It needs to be set internally for the query object to have default argument
         // values. However, we can query for .getParameters() to get user provided argument parameters.
-        if (fromID != null) conditionsList.add(str(Graql.Token.Compute.Condition.FROM, Graql.Token.Char.SPACE, Graql.Token.Char.QUOTE, fromID, Graql.Token.Char.QUOTE));
-        if (toID != null) conditionsList.add(str(Graql.Token.Compute.Condition.TO, Graql.Token.Char.SPACE, Graql.Token.Char.QUOTE, toID, Graql.Token.Char.QUOTE));
+        if (fromID != null) conditionsList.add(str(Graql.Token.Compute.Condition.FROM, Graql.Token.Char.SPACE, fromID));
+        if (toID != null) conditionsList.add(str(Graql.Token.Compute.Condition.TO, Graql.Token.Char.SPACE, toID));
         if (ofTypes != null) conditionsList.add(printOf());
         if (inTypes != null) conditionsList.add(printIn());
         if (algorithm != null) conditionsList.add(printAlgorithm());

--- a/java/query/test/GraqlQueryTest.java
+++ b/java/query/test/GraqlQueryTest.java
@@ -121,15 +121,9 @@ public class GraqlQueryTest {
     }
 
     @Test
-    public void testQuoteIds() {
-        assertEquals("match $a (\"hello\tworld\");", match(var("a").rel(type("hello\tworld"))).toString());
-        assertEquals("match $a (\"hello\\tworld\");", match(var("a").rel(type("hello\\tworld"))).toString());
-    }
-
-    @Test
-    public void testQuoteIdsNumbers() {
+    public void testNumericTypeLabels() {
         assertEquals(
-                "match $a (\"1hi\");",
+                "match $a (1hi);",
                 match(var("a").rel(type("1hi"))).toString()
         );
     }
@@ -178,12 +172,6 @@ public class GraqlQueryTest {
 
         query = Graql.compute().centrality().using(K_CORE).in("movie", "person").of("person").where(min_k(5));
         assertEquivalent(query, "compute centrality of person, in [movie, person], using k-core, where min-k=5;");
-    }
-
-    @Test
-    public void testQueryToStringWithReservedKeywords() {
-        GraqlGet query = Graql.match(var("x").isa("isa")).get("x");
-        assertEquals("match $x isa \"isa\"; get $x;", query.toString());
     }
 
     @Test

--- a/java/statement/Statement.java
+++ b/java/statement/Statement.java
@@ -31,7 +31,6 @@ import graql.lang.statement.builder.StatementInstanceBuilder;
 import graql.lang.statement.builder.StatementRelationBuilder;
 import graql.lang.statement.builder.StatementThingBuilder;
 import graql.lang.statement.builder.StatementTypeBuilder;
-import graql.lang.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -280,7 +279,7 @@ public class Statement implements Pattern,
             // If there is only a label, we display that
             Optional<String> label = getType();
             if (label.isPresent()) {
-                return StringUtil.escapeLabelOrId(label.get());
+                return label.get();
             }
         }
 

--- a/java/util/StringUtil.java
+++ b/java/util/StringUtil.java
@@ -31,12 +31,6 @@ import java.util.Set;
 
 public class StringUtil {
     private static final Set<String> GRAQL_KEYWORDS = getKeywords();
-    // TODO: This is critical knowledge that is lost in a Util class.
-    //       Move it to the Query class along with other Syntax rules
-    //       once they are moved to //graql package
-    private static final Set<String> ALLOWED_ID_KEYWORDS = new HashSet<>(
-            Arrays.asList("min", "max", "median", "mean", "std", "sum", "count", "path", "cluster", "degrees", "members", "persist")
-    );
 
     public static String unescapeRegex(String regex) {
         return regex.replaceAll("\\\\/", "/");
@@ -52,16 +46,6 @@ public class StringUtil {
      */
     public static String quoteString(String string) {
         return "\"" + string + "\"";
-    }
-
-    public static String escapeLabelOrId(String value) {
-        // TODO: This regex should be saved in Query class once it is moved to //graql package
-        if (value.matches("^@?[a-zA-Z_][a-zA-Z0-9_-]*$") &&
-                (Graql.Token.Type.of(value) != null || ALLOWED_ID_KEYWORDS.contains(value) || !GRAQL_KEYWORDS.contains(value)) ) {
-            return value;
-        } else {
-            return quoteString(value);
-        }
     }
 
     /**


### PR DESCRIPTION
## What is the goal of this PR?

In the previous definition of the Graql grammar, we had a "leak" in the token pattern definition of type labels and ID values. Both of them were defined by the same token `identifier`, which allowed both `ID_` patterns and `STRING_` patterns. `STRING_` pattern literally means anything. We've refined the grammar to restrict the definition of type labels and ID values, by directly assigning `type_label` and `ID_` tokens wherever they are expected, and removed the `identifier` token which allowed `STRING_` tokens to be provided. This change results in a more strict and consistent grammar, and therefore less error-prone.

## What are the changes implemented in this PR?

- Refactored all of the token patterns for type labels (to have names beginning with `type_`
- Made `ID_` be independent of the definition of type labels
- Allowed `ID_` pattern to be a subset of patterns allowed for `type_name`
- Refactored the `Parser` to adapt to the new grammar
- Changed all query `.toString()` output to no longer put type labels and ID values in quotes (`"` or `'`)
- Made sure the token names follow the convention we've set (all tokens that describe a pattern beyond a literal value has an underscore `_` suffix)
- Grouped the `TYPE_CHAR` `fragments` with other fragment definitions