### PR TITLE
Cache Variable hashCode and add missing negation hashCode&equals

### DIFF
--- a/java/pattern/Conjunction.java
+++ b/java/pattern/Conjunction.java
@@ -51,6 +51,19 @@ public class Conjunction<T extends Pattern> implements Pattern {
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Conjunction<?> that = (Conjunction<?>) o;
+        return Objects.equals(patterns, that.patterns);
+    }
+
+    @Override
+    public int hashCode() {
+        return patterns.hashCode();
+    }
+
     /**
      * @return the patterns within this conjunction
      */
@@ -112,25 +125,5 @@ public class Conjunction<T extends Pattern> implements Pattern {
         pattern.append(Graql.Token.Char.SPACE).append(Graql.Token.Char.CURLY_CLOSE).append(Graql.Token.Char.SEMICOLON);
 
         return pattern.toString();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (o == this) {
-            return true;
-        }
-        if (o instanceof Conjunction) {
-            Conjunction<?> that = (Conjunction<?>) o;
-            return (this.patterns.equals(that.getPatterns()));
-        }
-        return false;
-    }
-
-    @Override
-    public int hashCode() {
-        int h = 1;
-        h *= 1000003;
-        h ^= this.patterns.hashCode();
-        return h;
     }
 }

--- a/java/pattern/Disjunction.java
+++ b/java/pattern/Disjunction.java
@@ -50,6 +50,19 @@ public class Disjunction<T extends Pattern> implements Pattern {
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Disjunction<?> that = (Disjunction<?>) o;
+        return Objects.equals(patterns, that.patterns);
+    }
+
+    @Override
+    public int hashCode() {
+        return patterns.hashCode();
+    }
+
     /**
      * @return the patterns within this disjunction
      */
@@ -108,25 +121,5 @@ public class Disjunction<T extends Pattern> implements Pattern {
         disjunction.append(Graql.Token.Char.SEMICOLON);
 
         return disjunction.toString();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (o == this) {
-            return true;
-        }
-        if (o instanceof Disjunction) {
-            Disjunction<?> that = (Disjunction<?>) o;
-            return (this.patterns.equals(that.getPatterns()));
-        }
-        return false;
-    }
-
-    @Override
-    public int hashCode() {
-        int h = 1;
-        h *= 1000003;
-        h ^= this.patterns.hashCode();
-        return h;
     }
 }

--- a/java/pattern/Negation.java
+++ b/java/pattern/Negation.java
@@ -22,6 +22,7 @@ import graql.lang.Graql;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
 
+import java.util.Objects;
 import javax.annotation.CheckReturnValue;
 import java.util.Collections;
 import java.util.Set;
@@ -40,6 +41,19 @@ public class Negation<T extends Pattern> implements Pattern {
             throw new NullPointerException("Null patterns");
         }
         this.pattern = pattern;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Negation<?> negation = (Negation<?>) o;
+        return Objects.equals(pattern, negation.pattern);
+    }
+
+    @Override
+    public int hashCode() {
+        return pattern.hashCode();
     }
 
     @CheckReturnValue

--- a/java/statement/Variable.java
+++ b/java/statement/Variable.java
@@ -35,6 +35,7 @@ public class Variable {
     private final Type type;
     private final boolean visible;
     private volatile String symbol;
+    private int hashCode = 0;
 
     public Variable() {
         this(true);
@@ -64,6 +65,24 @@ public class Variable {
         }
         this.type = type;
         this.visible = visible;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        // This equals implementation is special: it ignores whether a variable is user-defined
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Variable varName = (Variable) o;
+        return name().equals(varName.name());
+    }
+
+    @Override
+    public final int hashCode() {
+        // This hashCode implementation is special: it ignores whether a variable is user-defined
+        if (hashCode == 0) {
+            hashCode = name().hashCode();
+        }
+        return hashCode;
     }
 
     /**
@@ -128,23 +147,6 @@ public class Variable {
         } else {
             return Graql.Token.Char.$_.toString();
         }
-    }
-
-    @Override
-    public final boolean equals(Object o) {
-        // This equals implementation is special: it ignores whether a variable is user-defined
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        Variable varName = (Variable) o;
-
-        return name().equals(varName.name());
-    }
-
-    @Override
-    public final int hashCode() {
-        // This hashCode implementation is special: it ignores whether a variable is user-defined
-        return name().hashCode();
     }
 
     /**


### PR DESCRIPTION
## What is the goal of this PR?

During profiling it occurred to us that caching the hashCode of  `Variable` might be a good idea as it is called often. This PR introduces the change. Additionally we make equals and hashCode consistent for all patterns.
## What are the changes implemented in this PR?

- cache Variable hashCode
- add missing hashCode/equals to `Negation` pattern
- regenerate `Conjunction` and  `Disjunction` equals and hashcodes so that all patterns have the same equality logic
