### PR TITLE
Revert @rules_antlr to use mainline repo

### DIFF
--- a/dependencies/compilers/dependencies.bzl
+++ b/dependencies/compilers/dependencies.bzl
@@ -21,6 +21,6 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def antlr_dependencies():
     git_repository(
         name = "rules_antlr",
-        remote = "https://github.com/graknlabs/rules_antlr",
-        commit = "3d1806329d7c61241781f7578240d1ff17f9e5d8"
+        remote = "https://github.com/marcohu/rules_antlr",
+        tag = "0.2.0"
     )


### PR DESCRIPTION
## What is the goal of this PR?

Previously, a forked copy of `@rules_antlr` with several patches was used to generate ANTLR code. We can now use mainline repo since fixes we needed were merged.

## What are the changes implemented in this PR?

Use `marcohu/rules_antlr#0.2.0` instead of `graknlabs/rules_antlr`
