### PR TITLE
Prefixed artifact IDs of Maven packages with 'graql-'

### DIFF
--- a/grammar/BUILD
+++ b/grammar/BUILD
@@ -35,7 +35,7 @@ java_library(
     deps = [
         "//dependencies/maven/artifacts/org/antlr:antlr4-runtime", # sync version with @antlr4_runtime//jar
     ],
-    tags = ["maven_coordinates=io.graql:grammar:{pom_version}", "checkstyle_ignore"],
+    tags = ["maven_coordinates=io.graql:graql-grammar:{pom_version}", "checkstyle_ignore"],
 )
 
 assemble_maven(

--- a/java/BUILD
+++ b/java/BUILD
@@ -33,7 +33,7 @@ java_library(
         "//dependencies/maven/artifacts/org/antlr:antlr4-runtime", # sync version with @antlr4_runtime//jar
         "//dependencies/maven/artifacts/org/slf4j:slf4j-api",
     ],
-    tags = ["maven_coordinates=io.graql:lang:{pom_version}"],
+    tags = ["maven_coordinates=io.graql:graql-lang:{pom_version}"],
 )
 
 assemble_maven(


### PR DESCRIPTION
## What is the goal of this PR?

When deploying Maven JARs to Sonatype, the JARs are renamed to be `artifact-id-version.jar`, without the `group-id`. This is done in Sonatype because the JARs are organised into folders where the folder names represent the Group IDs. However, in certain build systems, e.g. Gradle, the JARs are collected under one directory, which means the JAR names are not unique enough to disambiguate itself from each other. We have now renamed the artifact ID of our Maven packages to be prefixed with `graql-` to solve this problem.

## What are the changes implemented in this PR?

Prefixed artifact IDs of Maven packages with 'graql-' (fixes https://github.com/graknlabs/grakn/issues/5127, fixes https://github.com/graknlabs/bazel-distribution/issues/112).