### PR TITLE
GraqlDelete Ignore limit filter

### DIFF
--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -246,7 +246,7 @@ public class Parser extends GraqlBaseVisitor {
                 .stream().map(this::visitPattern)
                 .collect(Collectors.toCollection(LinkedHashSet::new)));
 
-        if (ctx.filters().getChildCount() > 0) {
+        if (ctx.filters().getChildCount() == 0) {
             return new GraqlDelete(match, vars);
         } else {
             Triple<Filterable.Sorting, Long, Long> filters = visitFilters(ctx.filters());


### PR DESCRIPTION
## What is the goal of this PR?
A bug filed previously https://github.com/graknlabs/grakn/issues/5388 shows that `limit` is not applied to `match...delete` queries. An investigation showed that filters were not even leaving the Graql parser and becoming part of the parsed Graql objects.

## What are the changes implemented in this PR?
* Flip the incorrect conditional in in `visitQuery__delete` so that filters are included instead of ignored, if they exist!
