### PR TITLE
Use Github credential for release-cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: git push --delete origin graql-release-branch
+      - run: git push --delete https://$REPO_GITHUB_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH
 
 workflows:
   graql:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: git push --delete https://$REPO_GITHUB_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH
+      - run: git push --delete https://$REPO_GITHUB_TOKEN@github.com/graknlabs/graql $CIRCLE_BRANCH
 
 workflows:
   graql:


### PR DESCRIPTION
## What is the goal of this PR?

Use GitHub credential for release-cleanup. This removes the need for adding an additional SSH key to CircleCI.