### PR TITLE
Adapt to latest changes in bazel-distribution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,8 +72,8 @@ jobs:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run //grammar:deploy-maven -- snapshot $CIRCLE_SHA1
-          bazel run //java:deploy-maven -- snapshot $CIRCLE_SHA1
+          bazel run --define version=$(git rev-parse HEAD) //grammar:deploy-maven -- snapshot
+          bazel run --define version=$(git rev-parse HEAD) //java:deploy-maven -- snapshot
 
   test-deployment-maven:
     machine: true
@@ -129,8 +129,8 @@ jobs:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run //grammar:deploy-maven -- release $(cat VERSION)
-          bazel run //java:deploy-maven -- release $(cat VERSION)
+          bazel run --define version=$(cat VERSION) //grammar:deploy-maven -- release
+          bazel run --define version=$(cat VERSION) //java:deploy-maven -- release
 
   sync-dependencies-release:
     machine: true

--- a/grammar/BUILD
+++ b/grammar/BUILD
@@ -42,7 +42,6 @@ assemble_maven(
   name = "assemble-maven",
   target = ":java",
   package = "grammar",
-  version_file = "//:VERSION",
   workspace_refs = "@graknlabs_graql_workspace_refs//:refs.json"
 )
 

--- a/java/BUILD
+++ b/java/BUILD
@@ -39,7 +39,6 @@ assemble_maven(
   name = "assemble-maven",
   target = ":graql",
   package = "java",
-  version_file = "//:VERSION",
   workspace_refs = "@graknlabs_graql_workspace_refs//:refs.json"
 )
 


### PR DESCRIPTION
## What is the goal of this PR?

graknlabs/bazel-distribution#191 changed the way Maven JARs are built. This PR adapts `graql` to latest changes

## What are the changes implemented in this PR?

* Use `--define` to supply version to Maven deployment rule
* Remove `version_file` from `assemble_maven` arguments
