### PR TITLE
Integrate checking for unused Java dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
       - run: bazel run @graknlabs_build_tools//checkstyle:test-coverage
       - run-bazel-rbe:
           command: bazel build //...
+      - run: bazel run @graknlabs_build_tools//unused_deps -- list
 
   build-analysis:
     machine: true

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,6 +30,9 @@ graknlabs_common()
 load("@graknlabs_build_tools//distribution:dependencies.bzl", "graknlabs_bazel_distribution")
 graknlabs_bazel_distribution()
 
+load("@graknlabs_build_tools//unused_deps:dependencies.bzl", "unused_deps_dependencies")
+unused_deps_dependencies()
+
 
 ###########################
 # Load Bazel Dependencies #


### PR DESCRIPTION
## What is the goal of this PR?

Integrate checking for unused Java dependencies

## What are the changes implemented in this PR?

- Load `@graknlabs_build_tools//unused_deps`'s dependencies
- Check for unused dependencies in `build` CI job
