### PR TITLE
Fix a typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Further documentation: http://dev.grakn.ai/docs/client-api/java#client-api-title
 
    b) to build the JAR for a Maven application:
    ```
-   bazel build //:assembl-maven
+   bazel build //:assemble-maven
    ```
    The Maven JAR and POM will be produced at: 
    ```


### PR DESCRIPTION
## What is the goal of this PR?

Fix a typo in Bazel target name in `README`

## What are the changes implemented in this PR?

Replaces target name with correct one.