### PR TITLE
Datetime Milliseconds Decimal Representation

### DIFF
--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -346,11 +346,11 @@ fragment DATE_FRAGMENT_ : YEAR_ '-' MONTH_ '-' DAY_ ;
 fragment MONTH_         : [0-1][0-9] ;
 fragment DAY_           : [0-3][0-9] ;
 fragment YEAR_          : [0-9][0-9][0-9][0-9] | ('+' | '-') [0-9]+ ;
-fragment TIME_          : HOUR_ ':' MINUTE_ (':' SECOND_ ('.' MILLIS_)? )? ;
+fragment TIME_          : HOUR_ ':' MINUTE_ (':' SECOND_ ('.' SECOND_FRACTION_)? )? ;
 fragment HOUR_          : [0-2][0-9] ;
 fragment MINUTE_        : [0-6][0-9] ;
 fragment SECOND_        : [0-6][0-9] ;
-fragment MILLIS_        : [0-9] ([0-9] ([0-9])?)?; // between 1 and 3 digits
+fragment SECOND_FRACTION_   : [0-9] ([0-9] ([0-9])?)?; // between 1 and 3 digits
 fragment ESCAPE_SEQ_    : '\\' . ;
 
 COMMENT         : '#' .*? '\r'? ('\n' | EOF)    -> channel(HIDDEN) ;

--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -346,10 +346,11 @@ fragment DATE_FRAGMENT_ : YEAR_ '-' MONTH_ '-' DAY_ ;
 fragment MONTH_         : [0-1][0-9] ;
 fragment DAY_           : [0-3][0-9] ;
 fragment YEAR_          : [0-9][0-9][0-9][0-9] | ('+' | '-') [0-9]+ ;
-fragment TIME_          : HOUR_ ':' MINUTE_ (':' SECOND_)? ;
+fragment TIME_          : HOUR_ ':' MINUTE_ (':' SECOND_ ('.' MILLIS_)? )? ;
 fragment HOUR_          : [0-2][0-9] ;
 fragment MINUTE_        : [0-6][0-9] ;
-fragment SECOND_        : [0-6][0-9] ('.' [0-9]+)? ;
+fragment SECOND_        : [0-6][0-9] ;
+fragment MILLIS_        : [0-9] ([0-9] ([0-9])?)?; // between 1 and 3 digits
 fragment ESCAPE_SEQ_    : '\\' . ;
 
 COMMENT         : '#' .*? '\r'? ('\n' | EOF)    -> channel(HIDDEN) ;

--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -238,7 +238,7 @@ unreserved          : MIN | MAX| MEDIAN | MEAN | STD | SUM | COUNT
 MATCH           : 'match'       ;   GET             : 'get'         ;
 DEFINE          : 'define'      ;   UNDEFINE        : 'undefine'    ;
 INSERT          : 'insert'      ;   DELETE          : 'delete'      ;
-AGGREGATE       : 'aggregate'   ;   COMPUTE         : 'compute'     ;
+COMPUTE         : 'compute'     ;
 
 // NATIVE TYPE KEYWORDS
 

--- a/java/exception/ErrorMessage.java
+++ b/java/exception/ErrorMessage.java
@@ -28,7 +28,10 @@ public enum ErrorMessage {
     INVALID_COMPUTE_CONDITION("Invalid condition(s) for 'compute [%s]'. The accepted condition(s) are: [%s]."),
     MISSING_COMPUTE_CONDITION("Missing condition(s) for 'compute [%s]'. The required condition(s) are: [%s]."),
     INVALID_COMPUTE_METHOD_ALGORITHM("Invalid algorithm for 'compute [%s]'. The accepted algorithm(s) are: [%s]."),
-    INVALID_COMPUTE_ARGUMENT("Invalid argument(s) 'compute [%s] using [%s]'. The accepted argument(s) are: [%s]."),;
+    INVALID_COMPUTE_ARGUMENT("Invalid argument(s) 'compute [%s] using [%s]'. The accepted argument(s) are: [%s]."),
+
+    OVERPRECISE_SECOND_FRACTION("LocalDateTime [%s] has sub-millisecond precision time. Precision up to 1 millisecond is supported");
+
 
     private final String message;
 

--- a/java/exception/GraqlException.java
+++ b/java/exception/GraqlException.java
@@ -21,6 +21,7 @@ package graql.lang.exception;
 
 import graql.lang.Graql;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -29,6 +30,7 @@ import static graql.lang.exception.ErrorMessage.INVALID_COMPUTE_CONDITION;
 import static graql.lang.exception.ErrorMessage.INVALID_COMPUTE_METHOD;
 import static graql.lang.exception.ErrorMessage.INVALID_COMPUTE_METHOD_ALGORITHM;
 import static graql.lang.exception.ErrorMessage.MISSING_COMPUTE_CONDITION;
+import static graql.lang.exception.ErrorMessage.OVERPRECISE_SECOND_FRACTION;
 
 public class GraqlException extends RuntimeException {
 
@@ -78,5 +80,9 @@ public class GraqlException extends RuntimeException {
 
     public static GraqlException invalidComputeQuery_invalidArgument(Graql.Token.Compute.Method method, Graql.Token.Compute.Algorithm algorithm, Set<Graql.Token.Compute.Param> accepted) {
         return new GraqlException(INVALID_COMPUTE_ARGUMENT.getMessage(method, algorithm, accepted));
+    }
+
+    public static GraqlException subsecondPrecisionTooPrecise(LocalDateTime localDateTime) {
+        return new GraqlException(OVERPRECISE_SECOND_FRACTION.getMessage(localDateTime));
     }
 }

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -289,7 +289,7 @@ public class ParserTest {
 
     @Test
     public void whenParsingDate_HandleMillis() {
-        String query = "match $x has release-date 1000-11-12T13:14:15.123; get;";
+        String query = "match $x has release-date 1000-11-12T13:14:15.12312; get;";
         GraqlGet expected = match(var("x").has("release-date", LocalDateTime.of(1000, 11, 12, 13, 14, 15, 123000000))).get();
         GraqlGet parsed = Graql.parse(query).asGet();
         assertQueryEquals(expected, parsed, query);
@@ -311,6 +311,13 @@ public class ParserTest {
         exception.expect(GraqlException.class);
         exception.expectMessage(Matchers.containsString("no viable alternative"));
         GraqlGet parsed = Graql.parse(query).asGet();
+    }
+
+    @Test
+    public void whenParsingDateTime_ErrorWhenHandlingOverPreciseNanos() {
+        exception.expect(GraqlException.class);
+        exception.expectMessage(Matchers.containsString("has sub-millisecond precision time"));
+        GraqlGet apiQuery = match(var("x").has("release-date", LocalDateTime.of(1000, 11, 12, 13, 14, 15, 123450000))).get();
     }
 
 
@@ -376,7 +383,7 @@ public class ParserTest {
 
     @Test
     public void testGetOffsetLimit() {
-        String query = "match $y isa movie, has title $n; get; offset 2; limit 4;" ;
+        String query = "match $y isa movie, has title $n; get; offset 2; limit 4;";
         GraqlGet parsed = Graql.parse(query).asGet();
         GraqlGet expected = match(
                 var("y").isa("movie").has("title", var("n"))
@@ -1049,7 +1056,7 @@ public class ParserTest {
         int numQueries = 10_000;
         String matchInsertString = "match $x isa person; insert $y isa person;\n";
         StringBuilder longQuery = new StringBuilder();
-        for(int i=0; i<numQueries; i++) {
+        for (int i = 0; i < numQueries; i++) {
             longQuery.append(matchInsertString);
         }
 

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -289,7 +289,7 @@ public class ParserTest {
 
     @Test
     public void whenParsingDate_HandleMillis() {
-        String query = "match $x has release-date 1000-11-12T13:14:15.12312; get;";
+        String query = "match $x has release-date 1000-11-12T13:14:15.123; get;";
         GraqlGet expected = match(var("x").has("release-date", LocalDateTime.of(1000, 11, 12, 13, 14, 15, 123000000))).get();
         GraqlGet parsed = Graql.parse(query).asGet();
         assertQueryEquals(expected, parsed, query);

--- a/java/property/ValueProperty.java
+++ b/java/property/ValueProperty.java
@@ -19,6 +19,7 @@
 package graql.lang.property;
 
 import graql.lang.Graql;
+import graql.lang.exception.GraqlException;
 import graql.lang.statement.Statement;
 import graql.lang.statement.StatementAttribute;
 import graql.lang.util.StringUtil;
@@ -188,6 +189,14 @@ public class ValueProperty<T> extends VarProperty {
 
                 public DateTime(LocalDateTime value) {
                     super(value);
+
+                    // validate precision of fractional seconds, which are stored as nanos in LocalDateTime
+                    int nanos = value.toLocalTime().getNano();
+                    long nanosPerMilli = 1000000L;
+                    long remainder = nanos % nanosPerMilli;
+                    if (remainder != 0) {
+                        throw GraqlException.subsecondPrecisionTooPrecise(value);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What is the goal of this PR?
Enable and test the inclusion of fractions of seconds in a date time attribute value, up to 3 digits, allowing us to store up to 999 milliseconds.
For example, `2019-01-01T10:10:10.123` will now parse as having `10.123` seconds, and `2019-01-01T10:10:10.1` will parse as having `10.100` seconds

Closes #93 

## What are the changes implemented in this PR?
* Implement and Test up to 3 digits after a `.` after seconds in a datetime