### PR TITLE
Update build-tools in order to fix the HTTPS issue when accessing Maven Central

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,7 +22,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "f758cf07c374c0a00ad822998cfe5b5fd8fac142", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "d425104710436ea95703149436ca9ff07f42b8a2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_common():


### PR DESCRIPTION
## What is the goal of this PR?

We have update build-tools to the one which connects to Maven Central with HTTPS.