### PR TITLE
Deletes accept statement_instance instead of variables

### DIFF
--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -39,7 +39,7 @@ query_undefine      :   UNDEFINE    statement_type+ ;
 query_insert        :   MATCH       pattern+    INSERT  statement_instance+
                     |                           INSERT  statement_instance+  ;
 
-query_delete        :   MATCH       pattern+    DELETE  variables   filters  ;  // GET QUERY followed by aggregate fn
+query_delete        :   MATCH       pattern+    DELETE  statement_instance+ filters  ;  // DELETE QUERY followed by aggregate fn
 query_get           :   MATCH       pattern+    GET     variables   filters  ;  // GET QUERY followed by group fn, and
                                                                                 // optionally, an aggregate fn
 query_compute       :   COMPUTE     compute_conditions  ;

--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -39,7 +39,7 @@ query_undefine      :   UNDEFINE    statement_type+ ;
 query_insert        :   MATCH       pattern+    INSERT  statement_instance+
                     |                           INSERT  statement_instance+  ;
 
-query_delete        :   MATCH       pattern+    DELETE  statement_instance+ filters  ;  // DELETE QUERY followed by aggregate fn
+query_delete        :   MATCH       pattern+    DELETE  statement_instance+ ;  // DELETE QUERY
 query_get           :   MATCH       pattern+    GET     variables   filters  ;  // GET QUERY followed by group fn, and
                                                                                 // optionally, an aggregate fn
 query_compute       :   COMPUTE     compute_conditions  ;

--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -38,8 +38,7 @@ query_undefine      :   UNDEFINE    statement_type+ ;
 
 query_insert        :   MATCH       pattern+    INSERT  statement_instance+
                     |                           INSERT  statement_instance+  ;
-
-query_delete        :   MATCH       pattern+    DELETE  statement_instance+ ;  // DELETE QUERY
+query_delete        :   MATCH       pattern+    DELETE  statement_instance+  ;  // DELETE QUERY
 query_get           :   MATCH       pattern+    GET     variables   filters  ;  // GET QUERY followed by group fn, and
                                                                                 // optionally, an aggregate fn
 query_compute       :   COMPUTE     compute_conditions  ;

--- a/java/exception/ErrorMessage.java
+++ b/java/exception/ErrorMessage.java
@@ -29,7 +29,8 @@ public enum ErrorMessage {
     INVALID_COMPUTE_METHOD_ALGORITHM("Invalid algorithm for 'compute [%s]'. The accepted algorithm(s) are: [%s]."),
     INVALID_COMPUTE_ARGUMENT("Invalid argument(s) 'compute [%s] using [%s]'. The accepted argument(s) are: [%s]."),
 
-    OVERPRECISE_SECOND_FRACTION("LocalDateTime [%s] has sub-millisecond precision time. Precision up to 1 millisecond is supported");
+    OVERPRECISE_SECOND_FRACTION("LocalDateTime [%s] has sub-millisecond precision time. Precision up to 1 millisecond is supported"),
+    SORTING_NOT_ALLOWED("Sorting [%s] not supported");
 
 
     private final String message;

--- a/java/exception/ErrorMessage.java
+++ b/java/exception/ErrorMessage.java
@@ -22,6 +22,7 @@ public enum ErrorMessage {
     SYNTAX_ERROR("syntax error at line %s: \n%s\n%s\n%s"),
     CONFLICTING_PROPERTIES("the following unique properties in '%s' conflict: '%s' and '%s'"),
     VARIABLE_OUT_OF_SCOPE("the variable [%s] is out of scope of the query"),
+    UNBOUND_DELETE_VARIABLE("the delete clause variable [%s] is not defined in the match clause"),
     NO_PATTERNS("no patterns have been provided. at least one pattern must be provided"),
     INVALID_COMPUTE_METHOD("Invalid compute method. The available compute methods are: [%s]."),
     INVALID_COMPUTE_CONDITION("Invalid condition(s) for 'compute [%s]'. The accepted condition(s) are: [%s]."),

--- a/java/exception/GraqlException.java
+++ b/java/exception/GraqlException.java
@@ -25,6 +25,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
+import static graql.lang.exception.ErrorMessage.CONFLICTING_PROPERTIES;
 import static graql.lang.exception.ErrorMessage.INVALID_COMPUTE_ARGUMENT;
 import static graql.lang.exception.ErrorMessage.INVALID_COMPUTE_CONDITION;
 import static graql.lang.exception.ErrorMessage.INVALID_COMPUTE_METHOD;
@@ -32,6 +33,8 @@ import static graql.lang.exception.ErrorMessage.INVALID_COMPUTE_METHOD_ALGORITHM
 import static graql.lang.exception.ErrorMessage.MISSING_COMPUTE_CONDITION;
 import static graql.lang.exception.ErrorMessage.OVERPRECISE_SECOND_FRACTION;
 import static graql.lang.exception.ErrorMessage.SORTING_NOT_ALLOWED;
+import static graql.lang.exception.ErrorMessage.UNBOUND_DELETE_VARIABLE;
+import static graql.lang.exception.ErrorMessage.VARIABLE_OUT_OF_SCOPE;
 
 public class GraqlException extends RuntimeException {
 
@@ -52,11 +55,15 @@ public class GraqlException extends RuntimeException {
     }
 
     public static GraqlException conflictingProperties(String statement, String property, String other) {
-        return new GraqlException(graql.lang.exception.ErrorMessage.CONFLICTING_PROPERTIES.getMessage(statement, property, other));
+        return new GraqlException(CONFLICTING_PROPERTIES.getMessage(statement, property, other));
     }
 
     public static GraqlException variableOutOfScope(String var) {
-        return new GraqlException(graql.lang.exception.ErrorMessage.VARIABLE_OUT_OF_SCOPE.getMessage(var));
+        return new GraqlException(VARIABLE_OUT_OF_SCOPE.getMessage(var));
+    }
+
+    public static GraqlException deleteVariableUnbound(String var) {
+        return new GraqlException(UNBOUND_DELETE_VARIABLE.getMessage(var));
     }
 
     public static GraqlException noPatterns() {

--- a/java/exception/GraqlException.java
+++ b/java/exception/GraqlException.java
@@ -19,6 +19,7 @@ package graql.lang.exception;
 
 
 import graql.lang.Graql;
+import graql.lang.query.builder.Filterable;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -30,6 +31,7 @@ import static graql.lang.exception.ErrorMessage.INVALID_COMPUTE_METHOD;
 import static graql.lang.exception.ErrorMessage.INVALID_COMPUTE_METHOD_ALGORITHM;
 import static graql.lang.exception.ErrorMessage.MISSING_COMPUTE_CONDITION;
 import static graql.lang.exception.ErrorMessage.OVERPRECISE_SECOND_FRACTION;
+import static graql.lang.exception.ErrorMessage.SORTING_NOT_ALLOWED;
 
 public class GraqlException extends RuntimeException {
 
@@ -83,5 +85,9 @@ public class GraqlException extends RuntimeException {
 
     public static GraqlException subsecondPrecisionTooPrecise(LocalDateTime localDateTime) {
         return new GraqlException(OVERPRECISE_SECOND_FRACTION.getMessage(localDateTime));
+    }
+
+    public static GraqlException sortingNotAllowed(Filterable.Sorting sorting) {
+        return new GraqlException(SORTING_NOT_ALLOWED.getMessage(sorting));
     }
 }

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -240,16 +240,19 @@ public class Parser extends GraqlBaseVisitor {
 
     @Override
     public GraqlDelete visitQuery_delete(GraqlParser.Query_deleteContext ctx) {
-        LinkedHashSet<Variable> vars = visitVariables(ctx.variables());
+        List<Statement> statements = ctx.statement_instance().stream()
+                .map(this::visitStatement_instance)
+                .collect(toList());
+
         MatchClause match = Graql.match(ctx.pattern()
                 .stream().map(this::visitPattern)
                 .collect(Collectors.toCollection(LinkedHashSet::new)));
 
         if (ctx.filters().getChildCount() == 0) {
-            return new GraqlDelete(match, vars);
+            return new GraqlDelete(match, statements);
         } else {
             Triple<Filterable.Sorting, Long, Long> filters = visitFilters(ctx.filters());
-            return new GraqlDelete(match, vars, filters.first(), filters.second(), filters.third());
+            return new GraqlDelete(match, statements, filters.first(), filters.second(), filters.third());
         }
     }
 

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -248,12 +248,7 @@ public class Parser extends GraqlBaseVisitor {
                 .stream().map(this::visitPattern)
                 .collect(Collectors.toCollection(LinkedHashSet::new)));
 
-        if (ctx.filters().getChildCount() == 0) {
-            return new GraqlDelete(match, statements);
-        } else {
-            Triple<Filterable.Sorting, Long, Long> filters = visitFilters(ctx.filters());
-            return new GraqlDelete(match, statements, filters.first(), filters.second(), filters.third());
-        }
+        return new GraqlDelete(match, statements);
     }
 
     @Override
@@ -304,8 +299,8 @@ public class Parser extends GraqlBaseVisitor {
         GraqlParser.Function_aggregateContext function = ctx.function_aggregate();
 
         return new GraqlGet.Aggregate(visitQuery_get(ctx.query_get()),
-                                      Graql.Token.Aggregate.Method.of(function.function_method().getText()),
-                                      function.VAR_() != null ? getVar(function.VAR_()) : null);
+                Graql.Token.Aggregate.Method.of(function.function_method().getText()),
+                function.VAR_() != null ? getVar(function.VAR_()) : null);
     }
 
     @Override
@@ -320,8 +315,8 @@ public class Parser extends GraqlBaseVisitor {
         GraqlParser.Function_aggregateContext function = ctx.function_aggregate();
 
         return new GraqlGet.Group.Aggregate(visitQuery_get(ctx.query_get()).group(var),
-                                            Graql.Token.Aggregate.Method.of(function.function_method().getText()),
-                                            function.VAR_() != null ? getVar(function.VAR_()) : null);
+                Graql.Token.Aggregate.Method.of(function.function_method().getText()),
+                function.VAR_() != null ? getVar(function.VAR_()) : null);
     }
 
     // DELETE AND GET QUERY MODIFIERS ==========================================
@@ -632,7 +627,7 @@ public class Parser extends GraqlBaseVisitor {
             } else if (property.RELATES() != null) {
                 if (property.AS() != null) {
                     type = type.relates(visitType(property.type(0)),
-                                        visitType(property.type(1)));
+                            visitType(property.type(1)));
                 } else {
                     type = type.relates(visitType(property.type(0)));
                 }
@@ -685,7 +680,8 @@ public class Parser extends GraqlBaseVisitor {
         }
     }
 
-    @Override @SuppressWarnings("Duplicates")
+    @Override
+    @SuppressWarnings("Duplicates")
     public Statement visitStatement_thing(GraqlParser.Statement_thingContext ctx) {
         // TODO: restrict for Insert VS Match
 
@@ -710,7 +706,8 @@ public class Parser extends GraqlBaseVisitor {
         return instance;
     }
 
-    @Override @SuppressWarnings("Duplicates")
+    @Override
+    @SuppressWarnings("Duplicates")
     public Statement visitStatement_relation(GraqlParser.Statement_relationContext ctx) {
         // TODO: restrict for Insert VS Match
 
@@ -735,7 +732,8 @@ public class Parser extends GraqlBaseVisitor {
         return instance;
     }
 
-    @Override @SuppressWarnings("Duplicates")
+    @Override
+    @SuppressWarnings("Duplicates")
     public Statement visitStatement_attribute(GraqlParser.Statement_attributeContext ctx) {
         // TODO: restrict for Insert VS Match
 
@@ -1039,7 +1037,7 @@ public class Parser extends GraqlBaseVisitor {
 
     private LocalDateTime getDate(TerminalNode date) {
         return LocalDate.parse(date.getText(),
-                               DateTimeFormatter.ISO_LOCAL_DATE).atStartOfDay();
+                DateTimeFormatter.ISO_LOCAL_DATE).atStartOfDay();
     }
 
     private LocalDateTime getDateTime(TerminalNode dateTime) {

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -501,12 +501,14 @@ public class ParserTest {
         String query = "match\n" +
                 "$x isa movie, has title 'The Title';\n" +
                 "$y isa movie;\n" +
-                "delete $x, $y;";
+                "delete\n" +
+                "$x isa movie;\n" +
+                "$y isa movie;";
         GraqlDelete parsed = Graql.parse(query).asDelete();
         GraqlDelete expected = match(
                 var("x").isa("movie").has("title", "The Title"),
                 var("y").isa("movie")
-        ).delete(Graql.parsePatternList("$x isa movie; $y isa movie"));
+        ).delete(Graql.parsePattern("{$x isa movie; $y isa movie;};").statements());
 
         assertQueryEquals(expected, parsed, query.replace("'", "\""));
     }

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -514,21 +514,6 @@ public class ParserTest {
     }
 
     @Test
-    public void whenParsingDeleteQueryWithNoArguments_ResultIsSameAsJavaGraql() {
-        String query = "match\n" +
-                "$x isa movie, has title 'The Title';\n" +
-                "$y isa movie;\n" +
-                "delete;";
-        GraqlDelete parsed = Graql.parse(query).asDelete();
-        GraqlDelete expected = match(
-                var("x").isa("movie").has("title", "The Title"),
-                var("y").isa("movie")
-        ).delete();
-
-        assertQueryEquals(expected, parsed, query.replace("'", "\""));
-    }
-
-    @Test
     public void whenParsingInsertQuery_ResultIsSameAsJavaGraql() {
         String query = "insert\n" +
                 "$x isa pokemon, has name 'Pichu';\n" +

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -506,7 +506,7 @@ public class ParserTest {
         GraqlDelete expected = match(
                 var("x").isa("movie").has("title", "The Title"),
                 var("y").isa("movie")
-        ).delete("x", "y");
+        ).delete(Graql.parsePatternList("$x isa movie; $y isa movie"));
 
         assertQueryEquals(expected, parsed, query.replace("'", "\""));
     }

--- a/java/query/GraqlDelete.java
+++ b/java/query/GraqlDelete.java
@@ -68,6 +68,10 @@ public class GraqlDelete extends GraqlQuery {
         return match;
     }
 
+    public List<Statement> statements() {
+        return delete;
+    }
+
     public Set<Variable> vars() {
         if (delete.isEmpty()) return match.getPatterns().variables();
         return delete.stream().flatMap(statement -> statement.variables().stream()).collect(Collectors.toSet());

--- a/java/query/GraqlDelete.java
+++ b/java/query/GraqlDelete.java
@@ -69,7 +69,7 @@ public class GraqlDelete extends GraqlQuery implements Filterable {
         delete.forEach(statement ->{
             for (Variable var : statement.variables()) {
                 if (!match.getSelectedNames().contains(var)) {
-                    throw GraqlException.variableOutOfScope(var.toString());
+                    throw GraqlException.deleteVariableUnbound(var.toString());
                 }
             }
         });

--- a/java/query/MatchClause.java
+++ b/java/query/MatchClause.java
@@ -135,54 +135,21 @@ public class MatchClause {
     }
 
     /**
-     * Construct a delete query with all all variables mentioned in the query
-     */
-    @CheckReturnValue
-    public GraqlDelete.Unfiltered delete() {
-        return delete(Collections.emptyList());
-    }
-
-    /**
-     * @param vars an array of variables to delete for each result of this match clause
+     * @param statements, an array of statements that indicate properties to delete
      * @return a delete query that will delete the given variables for each result of this match clause
      */
     @CheckReturnValue
-    public final GraqlDelete.Unfiltered delete(String var, String... vars) {
-        LinkedHashSet<Variable> varSet = Stream
-                .concat(Stream.of(var), Stream.of(vars))
-                .map(Variable::new)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-        return delete(varSet);
+    public final GraqlDelete.Unfiltered delete(Statement... statements) {
+        return delete(Arrays.asList(statements));
     }
 
     /**
-     * @param vars an array of variables to delete for each result of this match clause
+     * @param delete a collection of statements that indicate properties to delete
      * @return a delete query that will delete the given variables for each result of this match clause
      */
     @CheckReturnValue
-    public final GraqlDelete.Unfiltered delete(Variable var, Variable... vars) {
-        LinkedHashSet<Variable> varSet = new LinkedHashSet<>();
-        varSet.add(var);
-        varSet.addAll(Arrays.asList(vars));
-        return delete(varSet);
-    }
-
-    /**
-     * @param vars a collection of variables to delete for each result of this match clause
-     * @return a delete query that will delete the given variables for each result of this match clause
-     */
-    @CheckReturnValue
-    public final GraqlDelete.Unfiltered delete(List<Variable> vars) {
-        return delete(new LinkedHashSet<>(vars));
-    }
-
-    /**
-     * @param vars a collection of variables to delete for each result of this match clause
-     * @return a delete query that will delete the given variables for each result of this match clause
-     */
-    @CheckReturnValue
-    public final GraqlDelete.Unfiltered delete(LinkedHashSet<Variable> vars) {
-        return new GraqlDelete.Unfiltered(this, vars);
+    public final GraqlDelete.Unfiltered delete(Collection<? extends Statement> delete) {
+        return new GraqlDelete.Unfiltered(this, new ArrayList<>(delete));
     }
 
     @Override

--- a/java/query/MatchClause.java
+++ b/java/query/MatchClause.java
@@ -116,22 +116,22 @@ public class MatchClause {
     }
 
     /**
-     * @param vars an array of variables to insert for each result of this match clause
+     * @param statements an array of variables to insert for each result of this match clause
      * @return an insert query that will insert the given variables for each result of this match clause
      */
     @CheckReturnValue
-    public final GraqlInsert insert(Statement... vars) {
-        return insert(Arrays.asList(vars));
+    public final GraqlInsert insert(Statement... statements) {
+        return insert(Arrays.asList(statements));
     }
 
     /**
-     * @param vars a collection of variables to insert for each result of this match clause
+     * @param statements a collection of variables to insert for each result of this match clause
      * @return an insert query that will insert the given variables for each result of this match clause
      */
     @CheckReturnValue
-    public final GraqlInsert insert(Collection<? extends Statement> vars) {
+    public final GraqlInsert insert(Collection<? extends Statement> statements) {
         MatchClause match = this;
-        return new GraqlInsert(match, Collections.unmodifiableList(new ArrayList<>(vars)));
+        return new GraqlInsert(match, Collections.unmodifiableList(new ArrayList<>(statements)));
     }
 
     /**

--- a/java/query/MatchClause.java
+++ b/java/query/MatchClause.java
@@ -144,12 +144,12 @@ public class MatchClause {
     }
 
     /**
-     * @param delete a collection of statements that indicate properties to delete
+     * @param statements a collection of statements that indicate properties to delete
      * @return a delete query that will delete the given variables for each result of this match clause
      */
     @CheckReturnValue
-    public final GraqlDelete delete(Collection<? extends Statement> delete) {
-        return new GraqlDelete(this, new ArrayList<>(delete));
+    public final GraqlDelete delete(Collection<? extends Statement> statements) {
+        return new GraqlDelete(this, new ArrayList<>(statements));
     }
 
     @Override

--- a/java/query/MatchClause.java
+++ b/java/query/MatchClause.java
@@ -139,7 +139,7 @@ public class MatchClause {
      * @return a delete query that will delete the given variables for each result of this match clause
      */
     @CheckReturnValue
-    public final GraqlDelete.Unfiltered delete(Statement... statements) {
+    public final GraqlDelete delete(Statement... statements) {
         return delete(Arrays.asList(statements));
     }
 
@@ -148,8 +148,8 @@ public class MatchClause {
      * @return a delete query that will delete the given variables for each result of this match clause
      */
     @CheckReturnValue
-    public final GraqlDelete.Unfiltered delete(Collection<? extends Statement> delete) {
-        return new GraqlDelete.Unfiltered(this, new ArrayList<>(delete));
+    public final GraqlDelete delete(Collection<? extends Statement> delete) {
+        return new GraqlDelete(this, new ArrayList<>(delete));
     }
 
     @Override

--- a/java/query/test/BUILD
+++ b/java/query/test/BUILD
@@ -34,7 +34,6 @@ java_test(
     srcs = ["GraqlDeleteTest.java"],
     deps = [
         "//java:graql",
-        "@graknlabs_common//:common",
     ],
     size = "small"
 )

--- a/java/query/test/GraqlDeleteTest.java
+++ b/java/query/test/GraqlDeleteTest.java
@@ -18,6 +18,7 @@
 package graql.lang.query.test;
 
 import graql.lang.Graql;
+import graql.lang.exception.ErrorMessage;
 import graql.lang.exception.GraqlException;
 import graql.lang.query.GraqlDelete;
 import graql.lang.query.MatchClause;
@@ -26,6 +27,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -64,5 +66,19 @@ public class GraqlDeleteTest {
         exception.expect(GraqlException.class);
         exception.expectMessage("the delete clause variable [$y] is not defined in the match clause");
         GraqlDelete query = new GraqlDelete(match1, delete2);
+    }
+
+    @Test
+    public void deleteQueryWithoutStatementsThrows() {
+        exception.expect(GraqlException.class);
+        exception.expectMessage(ErrorMessage.NO_PATTERNS.getMessage());
+        GraqlDelete query = new GraqlDelete(match1, new ArrayList<>());
+    }
+
+    @Test
+    public void deleteQueryWithBuilderWithoutStatementThrows() {
+        exception.expect(GraqlException.class);
+        exception.expectMessage(ErrorMessage.NO_PATTERNS.getMessage());
+        GraqlDelete query = match1.delete();
     }
 }

--- a/java/query/test/GraqlDeleteTest.java
+++ b/java/query/test/GraqlDeleteTest.java
@@ -17,42 +17,52 @@
 
 package graql.lang.query.test;
 
-import grakn.common.util.Collections;
 import graql.lang.Graql;
+import graql.lang.exception.GraqlException;
 import graql.lang.query.GraqlDelete;
 import graql.lang.query.MatchClause;
-import graql.lang.statement.Variable;
+import graql.lang.statement.Statement;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
-import java.util.Collection;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.List;
 
 import static graql.lang.Graql.var;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 public class GraqlDeleteTest {
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
 
     private final MatchClause match1 = Graql.match(var("x").isa("movie"));
     private final MatchClause match2 = Graql.match(var("y").isa("movie"));
 
-    private final Collection<Variable> vars1 = Collections.set(new Variable("x"));
-    private final Collection<Variable> vars2 = Collections.set(new Variable("y"));
+    private final List<Statement> delete1 = Arrays.asList(var("x").isa("movie"));
+    private final List<Statement> delete2 = Arrays.asList(var("y").isa("movie"));
 
     @Test
     public void deleteQueriesWithTheSameMatchAndVarsAreEqual() {
-        GraqlDelete query1 = new GraqlDelete(match1, new LinkedHashSet<>(vars1));
-        GraqlDelete query2 = new GraqlDelete(match1, new LinkedHashSet<>(vars1));
-
+        GraqlDelete query1 = new GraqlDelete(match1, delete1);
+        GraqlDelete query2 = new GraqlDelete(match1, delete1);
         assertEquals(query1, query2);
         assertEquals(query1.hashCode(), query2.hashCode());
     }
 
     @Test
     public void deleteQueriesWithDifferentMatchesOrVarsAreDifferent() {
-        GraqlDelete query1 = new GraqlDelete(match1, new LinkedHashSet<>(vars1));
-        GraqlDelete query2 = new GraqlDelete(match2, new LinkedHashSet<>(vars2));
-
+        GraqlDelete query1 = new GraqlDelete(match1, delete1);
+        GraqlDelete query2 = new GraqlDelete(match2, delete2);
         assertNotEquals(query1, query2);
+    }
+
+    @Test
+    public void deleteQueryWithNewUnboundVariablesThrows() {
+        exception.expect(GraqlException.class);
+        exception.expectMessage("the delete clause variable [$y] is not defined in the match clause");
+        GraqlDelete query = new GraqlDelete(match1, delete2);
     }
 }

--- a/java/query/test/GraqlQueryTest.java
+++ b/java/query/test/GraqlQueryTest.java
@@ -201,8 +201,8 @@ public class GraqlQueryTest {
 
     @Test
     public void whenCallingToStringOnDeleteQuery_ItLooksLikeOriginalQuery() {
-        String query = "match $x isa movie; delete $x;";
-
+        String query = "match $x isa movie;\n" +
+                "delete $x isa movie;";
         assertEquals(query, Graql.parse(query).toString());
     }
 


### PR DESCRIPTION
## What is the goal of this PR?
Implementing the first step of https://github.com/graknlabs/graql/issues/115, we change the grammar to accept `statement_instance` for `delete` clauses, not just variables. As a medium term consequence, we remove the ability to limit, sort or offset delete queries.

## What are the changes implemented in this PR?
* Change `variables` to `statement_instance` in `delete` clauses
* Update tests to reflect not just using variables
* Add new test to ensure query throws if `delete` variable not present in the `match`
* Remove `Filterable` from delete queries
