### PR TITLE
Replaced the term 'DataType' with 'ValueType'

### DIFF
--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -103,7 +103,7 @@ type_property       :   ABSTRACT
                     |   HAS         type
                     |   PLAYS       type
                     |   RELATES     type ( AS type )?
-                    |   DATATYPE    datatype
+                    |   VALUETYPE   valuetype
                     |   REGEX       regex
                     |   WHEN    '{' pattern+              '}'
                     |   THEN    '{' statement_instance+   '}'                   // TODO: remove '+'
@@ -215,7 +215,7 @@ type_native         :   THING           |   ENTITY          |   ATTRIBUTE
                     |   RELATION        |   ROLE            |   RULE        ;
 type_name           :   TYPE_NAME_      |   TYPE_IMPLICIT_  |   ID_         ;
 
-datatype            :   LONG            |   DOUBLE          |   STRING
+valuetype            :   LONG            |   DOUBLE          |   STRING
                     |   BOOLEAN         |   DATE            ;
 literal             :   STRING_         |   INTEGER_        |   REAL_
                     |   BOOLEAN_        |   DATE_           |   DATETIME_   ;
@@ -261,7 +261,7 @@ ISA             : 'isa'         ;   ISAX            : 'isa!'        ;
 SUB             : 'sub'         ;   SUBX            : 'sub!'        ;
 KEY             : 'key'         ;   HAS             : 'has'         ;
 PLAYS           : 'plays'       ;   RELATES         : 'relates'     ;
-DATATYPE        : 'datatype'    ;   REGEX           : 'regex'       ;
+VALUETYPE       : 'valuetype'   ;   REGEX           : 'regex'       ;
 WHEN            : 'when'        ;   THEN            : 'then'        ;
 
 // GROUP AND AGGREGATE QUERY KEYWORDS (also used by COMPUTE QUERY)
@@ -291,7 +291,7 @@ EQV             : '=='          ;   NEQV            : '!=='         ;
 GT              : '>'           ;   GTE             : '>='          ;
 LT              : '<'           ;   LTE             : '<='          ;
 
-// DATA TYPE KEYWORDS
+// VALUE TYPE KEYWORDS
 
 LONG            : 'long'        ;   DOUBLE          : 'double'      ;
 STRING          : 'string'      ;   BOOLEAN         : 'boolean'     ;

--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -103,7 +103,7 @@ type_property       :   ABSTRACT
                     |   HAS         type
                     |   PLAYS       type
                     |   RELATES     type ( AS type )?
-                    |   VALUE   valuetype
+                    |   VALUE       type_value
                     |   REGEX       regex
                     |   WHEN    '{' pattern+              '}'
                     |   THEN    '{' statement_instance+   '}'                   // TODO: remove '+'
@@ -215,7 +215,7 @@ type_native         :   THING           |   ENTITY          |   ATTRIBUTE
                     |   RELATION        |   ROLE            |   RULE        ;
 type_name           :   TYPE_NAME_      |   TYPE_IMPLICIT_  |   ID_         ;
 
-valuetype           :   LONG            |   DOUBLE          |   STRING
+type_value          :   LONG            |   DOUBLE          |   STRING
                     |   BOOLEAN         |   DATE            ;
 value               :   STRING_         |   INTEGER_        |   REAL_
                     |   BOOLEAN_        |   DATE_           |   DATETIME_   ;

--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -103,7 +103,7 @@ type_property       :   ABSTRACT
                     |   HAS         type
                     |   PLAYS       type
                     |   RELATES     type ( AS type )?
-                    |   VALUETYPE   valuetype
+                    |   VALUE   valuetype
                     |   REGEX       regex
                     |   WHEN    '{' pattern+              '}'
                     |   THEN    '{' statement_instance+   '}'                   // TODO: remove '+'
@@ -149,13 +149,13 @@ attribute           :   HAS type_label ( VAR_ | operation ) via? ;              
 operation           :   assignment
                     |   comparison
                     ;
-assignment          :   literal   ;
+assignment          :   value ;
 comparison          :   comparator  comparable
                     |   CONTAINS    containable
                     |   LIKE        regex
                     ;
 comparator          :   EQV | NEQV | GT | GTE | LT | LTE ;
-comparable          :   literal | VAR_  ;
+comparable          :   value | VAR_  ;
 containable         :   STRING_ | VAR_  ;
 
 
@@ -215,9 +215,9 @@ type_native         :   THING           |   ENTITY          |   ATTRIBUTE
                     |   RELATION        |   ROLE            |   RULE        ;
 type_name           :   TYPE_NAME_      |   TYPE_IMPLICIT_  |   ID_         ;
 
-valuetype            :   LONG            |   DOUBLE          |   STRING
+valuetype           :   LONG            |   DOUBLE          |   STRING
                     |   BOOLEAN         |   DATE            ;
-literal             :   STRING_         |   INTEGER_        |   REAL_
+value               :   STRING_         |   INTEGER_        |   REAL_
                     |   BOOLEAN_        |   DATE_           |   DATETIME_   ;
 regex               :   STRING_         ;
 
@@ -261,7 +261,7 @@ ISA             : 'isa'         ;   ISAX            : 'isa!'        ;
 SUB             : 'sub'         ;   SUBX            : 'sub!'        ;
 KEY             : 'key'         ;   HAS             : 'has'         ;
 PLAYS           : 'plays'       ;   RELATES         : 'relates'     ;
-VALUETYPE       : 'valuetype'   ;   REGEX           : 'regex'       ;
+VALUE           : 'value'   ;   REGEX           : 'regex'       ;
 WHEN            : 'when'        ;   THEN            : 'then'        ;
 
 // GROUP AND AGGREGATE QUERY KEYWORDS (also used by COMPUTE QUERY)

--- a/java/Graql.java
+++ b/java/Graql.java
@@ -691,7 +691,7 @@ public class Graql {
         }
 
         public enum Property {
-            DATA_TYPE("datatype"),
+            VALUETYPE("valuetype"),
             HAS("has"),
             KEY("key"),
             VIA("via"),
@@ -730,7 +730,7 @@ public class Graql {
             }
         }
 
-        public enum DataType {
+        public enum ValueType {
             BOOLEAN("boolean"),
             DATE("date"),
             DOUBLE("double"),
@@ -739,7 +739,7 @@ public class Graql {
 
             private final String type;
 
-            DataType(String type) {
+            ValueType(String type) {
                 this.type = type;
             }
 
@@ -748,8 +748,8 @@ public class Graql {
                 return this.type;
             }
 
-            public static DataType of(String value) {
-                for (DataType c : DataType.values()) {
+            public static ValueType of(String value) {
+                for (ValueType c : ValueType.values()) {
                     if (c.type.equals(value)) {
                         return c;
                     }

--- a/java/Graql.java
+++ b/java/Graql.java
@@ -691,7 +691,8 @@ public class Graql {
         }
 
         public enum Property {
-            VALUETYPE("valuetype"),
+            VALUE(""),
+            VALUE_TYPE("value"),
             HAS("has"),
             KEY("key"),
             VIA("via"),
@@ -706,8 +707,7 @@ public class Graql {
             SUB("sub"),
             SUBX("sub!"),
             THEN("then"),
-            WHEN("when"),
-            VALUE("");
+            WHEN("when");
 
             private final String name;
 

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -633,8 +633,8 @@ public class Parser extends GraqlBaseVisitor {
                 } else {
                     type = type.relates(visitType(property.type(0)));
                 }
-            } else if (property.DATATYPE() != null) {
-                type = type.datatype(Graql.Token.DataType.of(property.datatype().getText()));
+            } else if (property.VALUETYPE() != null) {
+                type = type.valueType(Graql.Token.ValueType.of(property.valuetype().getText()));
 
             } else if (property.REGEX() != null) {
                 type = type.regex(visitRegex(property.regex()));
@@ -962,19 +962,19 @@ public class Parser extends GraqlBaseVisitor {
     }
 
     @Override
-    public Graql.Token.DataType visitDatatype(GraqlParser.DatatypeContext datatype) {
-        if (datatype.BOOLEAN() != null) {
-            return Graql.Token.DataType.BOOLEAN;
-        } else if (datatype.DATE() != null) {
-            return Graql.Token.DataType.DATE;
-        } else if (datatype.DOUBLE() != null) {
-            return Graql.Token.DataType.DOUBLE;
-        } else if (datatype.LONG() != null) {
-            return Graql.Token.DataType.LONG;
-        } else if (datatype.STRING() != null) {
-            return Graql.Token.DataType.STRING;
+    public Graql.Token.ValueType visitValuetype(GraqlParser.ValuetypeContext valueType) {
+        if (valueType.BOOLEAN() != null) {
+            return Graql.Token.ValueType.BOOLEAN;
+        } else if (valueType.DATE() != null) {
+            return Graql.Token.ValueType.DATE;
+        } else if (valueType.DOUBLE() != null) {
+            return Graql.Token.ValueType.DOUBLE;
+        } else if (valueType.LONG() != null) {
+            return Graql.Token.ValueType.LONG;
+        } else if (valueType.STRING() != null) {
+            return Graql.Token.ValueType.STRING;
         } else {
-            throw new IllegalArgumentException("Unrecognised DataType: " + datatype);
+            throw new IllegalArgumentException("Unrecognised ValueType: " + valueType);
         }
     }
 

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -633,7 +633,7 @@ public class Parser extends GraqlBaseVisitor {
                 } else {
                     type = type.relates(visitType(property.type(0)));
                 }
-            } else if (property.VALUETYPE() != null) {
+            } else if (property.VALUE() != null) {
                 type = type.valueType(Graql.Token.ValueType.of(property.valuetype().getText()));
 
             } else if (property.REGEX() != null) {
@@ -870,7 +870,7 @@ public class Parser extends GraqlBaseVisitor {
 
     @Override
     public ValueProperty.Operation<?> visitAssignment(GraqlParser.AssignmentContext ctx) {
-        Object value = visitLiteral(ctx.literal());
+        Object value = visitValue(ctx.value());
 
         if (value instanceof Integer) {
             return new ValueProperty.Operation.Assignment.Number<>(((Integer) value));
@@ -912,8 +912,8 @@ public class Parser extends GraqlBaseVisitor {
         }
 
         if (ctx.comparable() != null) {
-            if (ctx.comparable().literal() != null) {
-                value = visitLiteral(ctx.comparable().literal());
+            if (ctx.comparable().value() != null) {
+                value = visitValue(ctx.comparable().value());
             } else if (ctx.comparable().VAR_() != null) {
                 value = new Statement(getVar(ctx.comparable().VAR_()));
             } else {
@@ -979,7 +979,7 @@ public class Parser extends GraqlBaseVisitor {
     }
 
     @Override
-    public Object visitLiteral(GraqlParser.LiteralContext ctx) {
+    public Object visitValue(GraqlParser.ValueContext ctx) {
         if (ctx.STRING_() != null) {
             return getString(ctx.STRING_());
 

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -634,7 +634,7 @@ public class Parser extends GraqlBaseVisitor {
                     type = type.relates(visitType(property.type(0)));
                 }
             } else if (property.VALUE() != null) {
-                type = type.valueType(Graql.Token.ValueType.of(property.valuetype().getText()));
+                type = type.valueType(Graql.Token.ValueType.of(property.type_value().getText()));
 
             } else if (property.REGEX() != null) {
                 type = type.regex(visitRegex(property.regex()));
@@ -962,7 +962,7 @@ public class Parser extends GraqlBaseVisitor {
     }
 
     @Override
-    public Graql.Token.ValueType visitValuetype(GraqlParser.ValuetypeContext valueType) {
+    public Graql.Token.ValueType visitType_value(GraqlParser.Type_valueContext valueType) {
         if (valueType.BOOLEAN() != null) {
             return Graql.Token.ValueType.BOOLEAN;
         } else if (valueType.DATE() != null) {

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -634,7 +634,7 @@ public class Parser extends GraqlBaseVisitor {
                     type = type.relates(visitType(property.type(0)));
                 }
             } else if (property.VALUE() != null) {
-                type = type.valueType(Graql.Token.ValueType.of(property.type_value().getText()));
+                type = type.value(Graql.Token.ValueType.of(property.type_value().getText()));
 
             } else if (property.REGEX() != null) {
                 type = type.regex(visitRegex(property.regex()));

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -20,7 +20,7 @@ package graql.lang.parser.test;
 import graql.lang.Graql;
 import graql.lang.exception.GraqlException;
 import graql.lang.pattern.Pattern;
-import graql.lang.property.DataTypeProperty;
+import graql.lang.property.ValueTypeProperty;
 import graql.lang.query.GraqlCompute;
 import graql.lang.query.GraqlDefine;
 import graql.lang.query.GraqlDelete;
@@ -654,10 +654,10 @@ public class ParserTest {
     }
 
     @Test
-    public void testMatchDataTypeQuery() {
-        String query = "match $x datatype double; get;";
+    public void testMatchValueTypeQuery() {
+        String query = "match $x valuetype double; get;";
         GraqlGet parsed = Graql.parse(query).asGet();
-        GraqlGet expected = match(var("x").datatype(Graql.Token.DataType.DOUBLE)).get();
+        GraqlGet expected = match(var("x").valueType(Graql.Token.ValueType.DOUBLE)).get();
 
         assertQueryEquals(expected, parsed, query);
     }
@@ -672,19 +672,19 @@ public class ParserTest {
     }
 
     @Test
-    public void whenParsingDateKeyword_ParseAsTheCorrectDataType() {
-        String query = "match $x datatype date; get;";
+    public void whenParsingDateKeyword_ParseAsTheCorrectValueType() {
+        String query = "match $x valuetype date; get;";
         GraqlGet parsed = Graql.parse(query).asGet();
-        GraqlGet expected = match(var("x").datatype(Graql.Token.DataType.DATE)).get();
+        GraqlGet expected = match(var("x").valueType(Graql.Token.ValueType.DATE)).get();
 
         assertQueryEquals(expected, parsed, query);
     }
 
     @Test
-    public void testDefineDataTypeQuery() {
-        String query = "define my-type sub attribute, datatype long;";
+    public void testDefineValueTypeQuery() {
+        String query = "define my-type sub attribute, valuetype long;";
         GraqlDefine parsed = Graql.parse(query).asDefine();
-        GraqlDefine expected = define(type("my-type").sub("attribute").datatype(Graql.Token.DataType.LONG));
+        GraqlDefine expected = define(type("my-type").sub("attribute").valueType(Graql.Token.ValueType.LONG));
 
         assertQueryEquals(expected, parsed, query);
     }
@@ -959,14 +959,14 @@ public class ParserTest {
 
     @Test
     public void testParseBooleanType() {
-        GraqlGet query = parse("match $x datatype boolean; get;").asGet();
+        GraqlGet query = parse("match $x valuetype boolean; get;").asGet();
 
         Statement var = query.match().getPatterns().statements().iterator().next();
 
         //noinspection OptionalGetWithoutIsPresent
-        DataTypeProperty property = var.getProperty(DataTypeProperty.class).get();
+        ValueTypeProperty property = var.getProperty(ValueTypeProperty.class).get();
 
-        Assert.assertEquals(Graql.Token.DataType.BOOLEAN, property.dataType());
+        Assert.assertEquals(Graql.Token.ValueType.BOOLEAN, property.valueType());
     }
 
     @Test

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -657,7 +657,7 @@ public class ParserTest {
     public void testMatchValueTypeQuery() {
         String query = "match $x value double; get;";
         GraqlGet parsed = Graql.parse(query).asGet();
-        GraqlGet expected = match(var("x").valueType(Graql.Token.ValueType.DOUBLE)).get();
+        GraqlGet expected = match(var("x").value(Graql.Token.ValueType.DOUBLE)).get();
 
         assertQueryEquals(expected, parsed, query);
     }
@@ -675,7 +675,7 @@ public class ParserTest {
     public void whenParsingDateKeyword_ParseAsTheCorrectValueType() {
         String query = "match $x value date; get;";
         GraqlGet parsed = Graql.parse(query).asGet();
-        GraqlGet expected = match(var("x").valueType(Graql.Token.ValueType.DATE)).get();
+        GraqlGet expected = match(var("x").value(Graql.Token.ValueType.DATE)).get();
 
         assertQueryEquals(expected, parsed, query);
     }
@@ -684,7 +684,7 @@ public class ParserTest {
     public void testDefineValueTypeQuery() {
         String query = "define my-type sub attribute, value long;";
         GraqlDefine parsed = Graql.parse(query).asDefine();
-        GraqlDefine expected = define(type("my-type").sub("attribute").valueType(Graql.Token.ValueType.LONG));
+        GraqlDefine expected = define(type("my-type").sub("attribute").value(Graql.Token.ValueType.LONG));
 
         assertQueryEquals(expected, parsed, query);
     }

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -655,7 +655,7 @@ public class ParserTest {
 
     @Test
     public void testMatchValueTypeQuery() {
-        String query = "match $x valuetype double; get;";
+        String query = "match $x value double; get;";
         GraqlGet parsed = Graql.parse(query).asGet();
         GraqlGet expected = match(var("x").valueType(Graql.Token.ValueType.DOUBLE)).get();
 
@@ -673,7 +673,7 @@ public class ParserTest {
 
     @Test
     public void whenParsingDateKeyword_ParseAsTheCorrectValueType() {
-        String query = "match $x valuetype date; get;";
+        String query = "match $x value date; get;";
         GraqlGet parsed = Graql.parse(query).asGet();
         GraqlGet expected = match(var("x").valueType(Graql.Token.ValueType.DATE)).get();
 
@@ -682,7 +682,7 @@ public class ParserTest {
 
     @Test
     public void testDefineValueTypeQuery() {
-        String query = "define my-type sub attribute, valuetype long;";
+        String query = "define my-type sub attribute, value long;";
         GraqlDefine parsed = Graql.parse(query).asDefine();
         GraqlDefine expected = define(type("my-type").sub("attribute").valueType(Graql.Token.ValueType.LONG));
 
@@ -959,7 +959,7 @@ public class ParserTest {
 
     @Test
     public void testParseBooleanType() {
-        GraqlGet query = parse("match $x valuetype boolean; get;").asGet();
+        GraqlGet query = parse("match $x value boolean; get;").asGet();
 
         Statement var = query.match().getPatterns().statements().iterator().next();
 

--- a/java/property/ValueTypeProperty.java
+++ b/java/property/ValueTypeProperty.java
@@ -21,33 +21,33 @@ import graql.lang.Graql;
 import graql.lang.statement.StatementType;
 
 /**
- * Represents the {@code datatype} property on a AttributeType.
+ * Represents the {@code valuetype} property on a AttributeType.
  * This property can be queried or inserted.
  */
-public class DataTypeProperty extends VarProperty {
+public class ValueTypeProperty extends VarProperty {
 
-    private final Graql.Token.DataType dataType;
+    private final Graql.Token.ValueType valueType;
 
 
-    public DataTypeProperty(Graql.Token.DataType dataType) {
-        if (dataType == null) {
-            throw new NullPointerException("Null dataType");
+    public ValueTypeProperty(Graql.Token.ValueType valueType) {
+        if (valueType == null) {
+            throw new NullPointerException("Null valueType");
         }
-        this.dataType = dataType;
+        this.valueType = valueType;
     }
 
-    public Graql.Token.DataType dataType() {
-        return dataType;
+    public Graql.Token.ValueType valueType() {
+        return valueType;
     }
 
     @Override
     public String keyword() {
-        return Graql.Token.Property.DATA_TYPE.toString();
+        return Graql.Token.Property.VALUETYPE.toString();
     }
 
     @Override
     public String property() {
-        return dataType.toString();
+        return valueType.toString();
     }
 
     @Override
@@ -65,9 +65,9 @@ public class DataTypeProperty extends VarProperty {
         if (o == this) {
             return true;
         }
-        if (o instanceof DataTypeProperty) {
-            DataTypeProperty that = (DataTypeProperty) o;
-            return (this.dataType.equals(that.dataType()));
+        if (o instanceof ValueTypeProperty) {
+            ValueTypeProperty that = (ValueTypeProperty) o;
+            return (this.valueType.equals(that.valueType()));
         }
         return false;
     }
@@ -76,7 +76,7 @@ public class DataTypeProperty extends VarProperty {
     public int hashCode() {
         int h = 1;
         h *= 1000003;
-        h ^= this.dataType.hashCode();
+        h ^= this.valueType.hashCode();
         return h;
     }
 }

--- a/java/property/ValueTypeProperty.java
+++ b/java/property/ValueTypeProperty.java
@@ -42,7 +42,7 @@ public class ValueTypeProperty extends VarProperty {
 
     @Override
     public String keyword() {
-        return Graql.Token.Property.VALUETYPE.toString();
+        return Graql.Token.Property.VALUE_TYPE.toString();
     }
 
     @Override

--- a/java/query/test/GraqlQueryTest.java
+++ b/java/query/test/GraqlQueryTest.java
@@ -84,7 +84,7 @@ public class GraqlQueryTest {
 
     @Test
     public void testQueryWithValueTypeToString() {
-        assertSameStringRepresentation(Graql.match(var("x").valueType(Graql.Token.ValueType.LONG)).get());
+        assertSameStringRepresentation(Graql.match(var("x").value(Graql.Token.ValueType.LONG)).get());
     }
 
     @Test

--- a/java/query/test/GraqlQueryTest.java
+++ b/java/query/test/GraqlQueryTest.java
@@ -83,8 +83,8 @@ public class GraqlQueryTest {
     }
 
     @Test
-    public void testQueryWithDatatypeToString() {
-        assertSameStringRepresentation(Graql.match(var("x").datatype(Graql.Token.DataType.LONG)).get());
+    public void testQueryWithValueTypeToString() {
+        assertSameStringRepresentation(Graql.match(var("x").valueType(Graql.Token.ValueType.LONG)).get());
     }
 
     @Test

--- a/java/statement/builder/StatementTypeBuilder.java
+++ b/java/statement/builder/StatementTypeBuilder.java
@@ -209,8 +209,8 @@ public interface StatementTypeBuilder {
      * @return this
      */
     @CheckReturnValue
-    default StatementType valueType(String valueType) {
-        return valueType(Graql.Token.ValueType.of(valueType));
+    default StatementType value(String valueType) {
+        return value(Graql.Token.ValueType.of(valueType));
     }
 
     /**
@@ -218,7 +218,7 @@ public interface StatementTypeBuilder {
      * @return this
      */
     @CheckReturnValue
-    default StatementType valueType(Graql.Token.ValueType valueType) {
+    default StatementType value(Graql.Token.ValueType valueType) {
         return type(new ValueTypeProperty(valueType));
     }
 

--- a/java/statement/builder/StatementTypeBuilder.java
+++ b/java/statement/builder/StatementTypeBuilder.java
@@ -20,7 +20,7 @@ package graql.lang.statement.builder;
 import graql.lang.Graql;
 import graql.lang.pattern.Pattern;
 import graql.lang.property.AbstractProperty;
-import graql.lang.property.DataTypeProperty;
+import graql.lang.property.ValueTypeProperty;
 import graql.lang.property.HasAttributeTypeProperty;
 import graql.lang.property.PlaysProperty;
 import graql.lang.property.RegexProperty;
@@ -205,21 +205,21 @@ public interface StatementTypeBuilder {
     }
 
     /**
-     * @param datatype the datatype to set for this resource type variable
+     * @param valueType the valueType to set for this resource type variable
      * @return this
      */
     @CheckReturnValue
-    default StatementType datatype(String datatype) {
-        return datatype(Graql.Token.DataType.of(datatype));
+    default StatementType valueType(String valueType) {
+        return valueType(Graql.Token.ValueType.of(valueType));
     }
 
     /**
-     * @param datatype the datatype to set for this resource type variable
+     * @param valueType the valueType to set for this resource type variable
      * @return this
      */
     @CheckReturnValue
-    default StatementType datatype(Graql.Token.DataType datatype) {
-        return type(new DataTypeProperty(datatype));
+    default StatementType valueType(Graql.Token.ValueType valueType) {
+        return type(new ValueTypeProperty(valueType));
     }
 
     /**


### PR DESCRIPTION
## What is the goal of this PR?

We are replacing the term `DataType` in `AttributeType` with `ValueType`). Previously, an `AttributeType` has a `DataType`. And an `Attribute` has `Value`. The type of `Value` is defined by `DataType`. We can see the inconsistency there. Now, `AttributeType` has `ValueType`, and `Attribute` has `Value`. The type of `Value` is `ValueType`. So it's all consistent.

## What are the changes implemented in this PR?

- Renamed the `DataType` class to `ValueType`
- Renamed method names
- Renamed method arguments
- Renamed variable names
- Updated comments