### PR TITLE
Remove implicit variable statement

### DIFF
--- a/java/property/HasAttributeProperty.java
+++ b/java/property/HasAttributeProperty.java
@@ -38,23 +38,14 @@ public class HasAttributeProperty extends VarProperty {
 
     private final String type;
     private final Statement attribute;
-    private final Statement relation;
 
     public HasAttributeProperty(String type, Statement attribute) {
-        this(type, attribute, new Statement(new Variable()));
-    }
-
-    public HasAttributeProperty(String type, Statement attribute, Statement relation) {
         attribute = attribute.isa(Graql.type(type));
         if (type == null) {
             throw new NullPointerException("Null type");
         }
         this.type = type;
         this.attribute = attribute;
-        if (relation == null) {
-            throw new NullPointerException("Null relation");
-        }
-        this.relation = relation;
     }
 
     public String type() {
@@ -63,10 +54,6 @@ public class HasAttributeProperty extends VarProperty {
 
     public Statement attribute() {
         return attribute;
-    }
-
-    public Statement relation() {
-        return relation;
     }
 
     @Override
@@ -101,16 +88,12 @@ public class HasAttributeProperty extends VarProperty {
 
     @Override
     public Stream<Statement> statements() {
-        return Stream.of(attribute(), relation());
+        return Stream.of(attribute());
     }
 
     @Override
     public Class statementClass() {
         return StatementInstance.class;
-    }
-
-    private boolean hasReifiedRelation() {
-        return relation().properties().stream().findAny().isPresent() || relation().var().isReturned();
     }
 
     @Override
@@ -123,23 +106,13 @@ public class HasAttributeProperty extends VarProperty {
         if (!type().equals(that.type())) return false;
         if (!attribute().equals(that.attribute())) return false;
 
-        // TODO: Having to check this is pretty dodgy
-        // This check is necessary for `equals` and `hashCode` because `Statement` equality is defined
-        // s.t. `var() != var()`, but `var().label("movie") == var().label("movie")`
-        // i.e., a `Var` is compared by name, but a `Statement` ignores the name if the var is not user-defined
-        return !hasReifiedRelation() || relation().equals(that.relation());
+        return true;
     }
 
     @Override
     public int hashCode() {
         int result = type().hashCode();
         result = 31 * result + attribute().hashCode();
-
-        // TODO: Having to check this is pretty dodgy, explanation in #equals
-        if (hasReifiedRelation()) {
-            result = 31 * result + relation().hashCode();
-        }
-
         return result;
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?
The prior PR removed `via` from the language, but failed to remove the `relation` statement that represents the implicit attribute relation. This is always created per `HasAttributeProperty`. We now remove it.

## What are the changes implemented in this PR?
* Delete `relation` statement from `HasAttributeProperty`

This PR is actually also a step towards https://github.com/graknlabs/graql/issues/113