### PR TITLE
Renamed 'ValueType' to 'ValueClass' and 'date' to 'datetime'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,17 +45,6 @@ hs_err_pid*
 logs/
 *.log
 
-# Analytics files #
-grakn-test/db/
-grakn-test/output/
-grakn-test/*.txt
-
-# Sample Date Files #
-grakn-test/test-biomed/data/*
-
-# Benchmark Files #
-grakn-test/test-integration/benchmarks/
-
 # VIM swap files #
 *.swp
 *.swo

--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -102,7 +102,7 @@ type_property       :   ABSTRACT
                     |   HAS         type
                     |   PLAYS       type
                     |   RELATES     type ( AS type )?
-                    |   VALUE       type_value
+                    |   VALUE       value_class
                     |   REGEX       regex
                     |   WHEN    '{' pattern+              '}'
                     |   THEN    '{' statement_instance+   '}'                   // TODO: remove '+'
@@ -211,8 +211,8 @@ type_native         :   THING           |   ENTITY          |   ATTRIBUTE
                     |   RELATION        |   ROLE            |   RULE        ;
 type_name           :   TYPE_NAME_      |   TYPE_IMPLICIT_  |   ID_         ;
 
-type_value          :   LONG            |   DOUBLE          |   STRING
-                    |   BOOLEAN         |   DATE            ;
+value_class         :   LONG            |   DOUBLE          |   STRING
+                    |   BOOLEAN         |   DATETIME            ;
 value               :   STRING_         |   INTEGER_        |   REAL_
                     |   BOOLEAN_        |   DATE_           |   DATETIME_   ;
 regex               :   STRING_         ;
@@ -287,11 +287,11 @@ EQV             : '=='          ;   NEQV            : '!=='         ;
 GT              : '>'           ;   GTE             : '>='          ;
 LT              : '<'           ;   LTE             : '<='          ;
 
-// VALUE TYPE KEYWORDS
+// VALUE CLASS KEYWORDS
 
 LONG            : 'long'        ;   DOUBLE          : 'double'      ;
 STRING          : 'string'      ;   BOOLEAN         : 'boolean'     ;
-DATE            : 'date'        ;
+DATETIME        : 'datetime'        ;
 
 // LITERAL VALUE KEYWORDS
 BOOLEAN_        : TRUE | FALSE  ; // order of lexer declaration matters

--- a/java/Graql.java
+++ b/java/Graql.java
@@ -692,7 +692,7 @@ public class Graql {
 
         public enum Property {
             VALUE(""),
-            VALUE_TYPE("value"),
+            VALUE_CLASS("value"),
             HAS("has"),
             KEY("key"),
             ID("id"),
@@ -729,16 +729,16 @@ public class Graql {
             }
         }
 
-        public enum ValueType {
+        public enum ValueClass {
             BOOLEAN("boolean"),
-            DATE("date"),
+            DATETIME("datetime"),
             DOUBLE("double"),
             LONG("long"),
             STRING("string");
 
             private final String type;
 
-            ValueType(String type) {
+            ValueClass(String type) {
                 this.type = type;
             }
 
@@ -747,8 +747,8 @@ public class Graql {
                 return this.type;
             }
 
-            public static ValueType of(String value) {
-                for (ValueType c : ValueType.values()) {
+            public static ValueClass of(String value) {
+                for (ValueClass c : ValueClass.values()) {
                     if (c.type.equals(value)) {
                         return c;
                     }

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -632,7 +632,7 @@ public class Parser extends GraqlBaseVisitor {
                     type = type.relates(visitType(property.type(0)));
                 }
             } else if (property.VALUE() != null) {
-                type = type.value(Graql.Token.ValueType.of(property.type_value().getText()));
+                type = type.value(Graql.Token.ValueClass.of(property.value_class().getText()));
 
             } else if (property.REGEX() != null) {
                 type = type.regex(visitRegex(property.regex()));
@@ -955,19 +955,19 @@ public class Parser extends GraqlBaseVisitor {
     }
 
     @Override
-    public Graql.Token.ValueType visitType_value(GraqlParser.Type_valueContext valueType) {
-        if (valueType.BOOLEAN() != null) {
-            return Graql.Token.ValueType.BOOLEAN;
-        } else if (valueType.DATE() != null) {
-            return Graql.Token.ValueType.DATE;
-        } else if (valueType.DOUBLE() != null) {
-            return Graql.Token.ValueType.DOUBLE;
-        } else if (valueType.LONG() != null) {
-            return Graql.Token.ValueType.LONG;
-        } else if (valueType.STRING() != null) {
-            return Graql.Token.ValueType.STRING;
+    public Graql.Token.ValueClass visitValue_class(GraqlParser.Value_classContext valueClass) {
+        if (valueClass.BOOLEAN() != null) {
+            return Graql.Token.ValueClass.BOOLEAN;
+        } else if (valueClass.DATETIME() != null) {
+            return Graql.Token.ValueClass.DATETIME;
+        } else if (valueClass.DOUBLE() != null) {
+            return Graql.Token.ValueClass.DOUBLE;
+        } else if (valueClass.LONG() != null) {
+            return Graql.Token.ValueClass.LONG;
+        } else if (valueClass.STRING() != null) {
+            return Graql.Token.ValueClass.STRING;
         } else {
-            throw new IllegalArgumentException("Unrecognised ValueType: " + valueType);
+            throw new IllegalArgumentException("Unrecognised Value Class: " + valueClass);
         }
     }
 

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -20,7 +20,7 @@ package graql.lang.parser.test;
 import graql.lang.Graql;
 import graql.lang.exception.GraqlException;
 import graql.lang.pattern.Pattern;
-import graql.lang.property.ValueTypeProperty;
+import graql.lang.property.ValueClassProperty;
 import graql.lang.query.GraqlCompute;
 import graql.lang.query.GraqlDefine;
 import graql.lang.query.GraqlDelete;
@@ -641,10 +641,10 @@ public class ParserTest {
     }
 
     @Test
-    public void testMatchValueTypeQuery() {
+    public void testMatchValueClassQuery() {
         String query = "match $x value double; get;";
         GraqlGet parsed = Graql.parse(query).asGet();
-        GraqlGet expected = match(var("x").value(Graql.Token.ValueType.DOUBLE)).get();
+        GraqlGet expected = match(var("x").value(Graql.Token.ValueClass.DOUBLE)).get();
 
         assertQueryEquals(expected, parsed, query);
     }
@@ -659,19 +659,19 @@ public class ParserTest {
     }
 
     @Test
-    public void whenParsingDateKeyword_ParseAsTheCorrectValueType() {
-        String query = "match $x value date; get;";
+    public void whenParsingDateKeyword_ParseAsTheCorrectValueClass() {
+        String query = "match $x value datetime; get;";
         GraqlGet parsed = Graql.parse(query).asGet();
-        GraqlGet expected = match(var("x").value(Graql.Token.ValueType.DATE)).get();
+        GraqlGet expected = match(var("x").value(Graql.Token.ValueClass.DATETIME)).get();
 
         assertQueryEquals(expected, parsed, query);
     }
 
     @Test
-    public void testDefineValueTypeQuery() {
+    public void testDefineValueClassQuery() {
         String query = "define my-type sub attribute, value long;";
         GraqlDefine parsed = Graql.parse(query).asDefine();
-        GraqlDefine expected = define(type("my-type").sub("attribute").value(Graql.Token.ValueType.LONG));
+        GraqlDefine expected = define(type("my-type").sub("attribute").value(Graql.Token.ValueClass.LONG));
 
         assertQueryEquals(expected, parsed, query);
     }
@@ -951,9 +951,9 @@ public class ParserTest {
         Statement var = query.match().getPatterns().statements().iterator().next();
 
         //noinspection OptionalGetWithoutIsPresent
-        ValueTypeProperty property = var.getProperty(ValueTypeProperty.class).get();
+        ValueClassProperty property = var.getProperty(ValueClassProperty.class).get();
 
-        Assert.assertEquals(Graql.Token.ValueType.BOOLEAN, property.valueType());
+        Assert.assertEquals(Graql.Token.ValueClass.BOOLEAN, property.valueClass());
     }
 
     @Test

--- a/java/property/ValueClassProperty.java
+++ b/java/property/ValueClassProperty.java
@@ -21,33 +21,33 @@ import graql.lang.Graql;
 import graql.lang.statement.StatementType;
 
 /**
- * Represents the {@code valuetype} property on a AttributeType.
+ * Represents the {@code ValueClass} property on a AttributeType.
  * This property can be queried or inserted.
  */
-public class ValueTypeProperty extends VarProperty {
+public class ValueClassProperty extends VarProperty {
 
-    private final Graql.Token.ValueType valueType;
+    private final Graql.Token.ValueClass valueClass;
 
 
-    public ValueTypeProperty(Graql.Token.ValueType valueType) {
-        if (valueType == null) {
-            throw new NullPointerException("Null valueType");
+    public ValueClassProperty(Graql.Token.ValueClass valueClass) {
+        if (valueClass == null) {
+            throw new NullPointerException("Null ValueClass");
         }
-        this.valueType = valueType;
+        this.valueClass = valueClass;
     }
 
-    public Graql.Token.ValueType valueType() {
-        return valueType;
+    public Graql.Token.ValueClass valueClass() {
+        return valueClass;
     }
 
     @Override
     public String keyword() {
-        return Graql.Token.Property.VALUE_TYPE.toString();
+        return Graql.Token.Property.VALUE_CLASS.toString();
     }
 
     @Override
     public String property() {
-        return valueType.toString();
+        return valueClass.toString();
     }
 
     @Override
@@ -65,9 +65,9 @@ public class ValueTypeProperty extends VarProperty {
         if (o == this) {
             return true;
         }
-        if (o instanceof ValueTypeProperty) {
-            ValueTypeProperty that = (ValueTypeProperty) o;
-            return (this.valueType.equals(that.valueType()));
+        if (o instanceof ValueClassProperty) {
+            ValueClassProperty that = (ValueClassProperty) o;
+            return (this.valueClass.equals(that.valueClass()));
         }
         return false;
     }
@@ -76,7 +76,7 @@ public class ValueTypeProperty extends VarProperty {
     public int hashCode() {
         int h = 1;
         h *= 1000003;
-        h ^= this.valueType.hashCode();
+        h ^= this.valueClass.hashCode();
         return h;
     }
 }

--- a/java/query/test/GraqlQueryTest.java
+++ b/java/query/test/GraqlQueryTest.java
@@ -83,8 +83,8 @@ public class GraqlQueryTest {
     }
 
     @Test
-    public void testQueryWithValueTypeToString() {
-        assertSameStringRepresentation(Graql.match(var("x").value(Graql.Token.ValueType.LONG)).get());
+    public void testQueryWithValueClassToString() {
+        assertSameStringRepresentation(Graql.match(var("x").value(Graql.Token.ValueClass.LONG)).get());
     }
 
     @Test

--- a/java/statement/builder/StatementTypeBuilder.java
+++ b/java/statement/builder/StatementTypeBuilder.java
@@ -20,7 +20,7 @@ package graql.lang.statement.builder;
 import graql.lang.Graql;
 import graql.lang.pattern.Pattern;
 import graql.lang.property.AbstractProperty;
-import graql.lang.property.ValueTypeProperty;
+import graql.lang.property.ValueClassProperty;
 import graql.lang.property.HasAttributeTypeProperty;
 import graql.lang.property.PlaysProperty;
 import graql.lang.property.RegexProperty;
@@ -205,21 +205,21 @@ public interface StatementTypeBuilder {
     }
 
     /**
-     * @param valueType the valueType to set for this resource type variable
+     * @param valueClass the valueClass to set for this resource type variable
      * @return this
      */
     @CheckReturnValue
-    default StatementType value(String valueType) {
-        return value(Graql.Token.ValueType.of(valueType));
+    default StatementType value(String valueClass) {
+        return value(Graql.Token.ValueClass.of(valueClass));
     }
 
     /**
-     * @param valueType the valueType to set for this resource type variable
+     * @param valueClass the valueClass to set for this resource type variable
      * @return this
      */
     @CheckReturnValue
-    default StatementType value(Graql.Token.ValueType valueType) {
-        return type(new ValueTypeProperty(valueType));
+    default StatementType value(Graql.Token.ValueClass valueClass) {
+        return type(new ValueClassProperty(valueClass));
     }
 
     /**


### PR DESCRIPTION
## What is the goal of this PR?

With the new hypergraph `AttributeType` implementation, we no longer need the `Enum` `ValueType` in the server. We just pass a Java class such as `Boolean.class`, `Long.class`, etc, whenever needed - which is very rare. So the term `ValueType` (that previously refers to the enum containing a class) is now being changed again, to `ValueClass` (referring to the explicit Java class). Additionally, I realise this would be even better for understandability, as the suffix `Type` implies that it is a "Grakn Type", which therefore should be inheritable and have instances - which is not true for `ValueClass`.

Additionally, we're also renaming `date` to `datetime` to accurately describe the actual class it represents, and also allow us to introduce a `date` value class to represent explicitly only "dates".

## What are the changes implemented in this PR?

- Renamed the `ValueType` class to `ValueClass`
- Renamed method names
- Renamed method arguments
- Renamed variable names
- Updated comments