### PR TITLE
Allow `plays` to be scoped or unscoped

### DIFF
--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -95,18 +95,18 @@ pattern_statement   :   statement_type
 
 // TYPE STATEMENTS =============================================================
 
-statement_type      :   type        type_property ( ',' type_property )* ';' ;
+statement_type      :   type_ref type_property ( ',' type_property )* ';' ;
 type_property       :   ABSTRACT
-                    |   SUB_        type
+                    |   SUB_        type_ref
                     |   KEY         type
                     |   HAS         type
-                    |   PLAYS       type
+                    |   PLAYS       type_scoped
                     |   RELATES     type ( AS type )?
                     |   VALUE       value_type
                     |   REGEX       regex
                     |   WHEN    '{' pattern+              '}'
                     |   THEN    '{' statement_instance+   '}'                   // TODO: remove '+'
-                    |   TYPE        type_label
+                    |   TYPE        type_label_ref
                     ;
 
 // INSTANCE STATEMENTS =========================================================
@@ -199,11 +199,18 @@ compute_arg         :   MIN_K     '=' INTEGER_                                  
 
 // TYPE, LABEL AND IDENTIFIER CONSTRUCTS =======================================
 
-type                :   type_label      | VAR_ ;                                // A type can be a label or variable
-type_label          :   type_native     | type_name         | unreserved    ;
-type_labels         :   type_label      | type_label_array  ;
+// we have both scoped and unscoped types, both of which can just be vars
+type_ref            :   type                | type_scoped ;
+type_scoped         :   type_label_scoped   | VAR_        ;
+type                :   type_label          | VAR_        ;
 
-type_label_array    :   '[' type_label ( ',' type_label )* ']'              ;
+
+type_label_ref      :   type_label      |  type_label_scoped  ;
+type_label_scoped   :   type_label     ':' type_label         ;
+type_label          :   type_native     |  type_name          | unreserved  ;
+
+type_labels         :   type_label      | type_label_array      ;
+type_label_array    :   '[' type_label ( ',' type_label )* ']'  ;
 
 // LITERAL INPUT VALUES =======================================================
 

--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -95,18 +95,18 @@ pattern_statement   :   statement_type
 
 // TYPE STATEMENTS =============================================================
 
-statement_type      :   type_ref type_property ( ',' type_property )* ';' ;
+statement_type      :   type type_property ( ',' type_property )* ';' ;
 type_property       :   ABSTRACT
-                    |   SUB_        type_ref
-                    |   KEY         type
-                    |   HAS         type
-                    |   PLAYS       type_scoped
-                    |   RELATES     type ( AS type )?
+                    |   SUB_        type
+                    |   KEY         type_unscoped
+                    |   HAS         type_unscoped
+                    |   PLAYS       type
+                    |   RELATES     type_unscoped ( AS type_unscoped )?
                     |   VALUE       value_type
                     |   REGEX       regex
                     |   WHEN    '{' pattern+              '}'
                     |   THEN    '{' statement_instance+   '}'                   // TODO: remove '+'
-                    |   TYPE        type_label_ref
+                    |   TYPE        type_label
                     ;
 
 // INSTANCE STATEMENTS =========================================================
@@ -115,16 +115,16 @@ statement_instance  :   statement_thing
                     |   statement_relation
                     |   statement_attribute
                     ;
-statement_thing     :   VAR_                ISA_ type   ( ',' attributes )? ';'
+statement_thing     :   VAR_                ISA_ type_unscoped   ( ',' attributes )? ';'
                     |   VAR_                ID   ID_    ( ',' attributes )? ';'
                     |   VAR_                NEQ  VAR_                       ';'
                     |   VAR_                attributes                      ';'
                     ;
-statement_relation  :   VAR_? relation      ISA_ type   ( ',' attributes )? ';'
+statement_relation  :   VAR_? relation      ISA_ type_unscoped   ( ',' attributes )? ';'
                     |   VAR_? relation      attributes                      ';'
                     |   VAR_? relation                                      ';'
                     ;
-statement_attribute :   VAR_? operation     ISA_ type   ( ',' attributes )? ';'
+statement_attribute :   VAR_? operation     ISA_ type_unscoped   ( ',' attributes )? ';'
                     |   VAR_? operation     attributes                      ';'
                     |   VAR_? operation                                     ';'
                     ;
@@ -132,13 +132,13 @@ statement_attribute :   VAR_? operation     ISA_ type   ( ',' attributes )? ';'
 // RELATION CONSTRUCT ==========================================================
 
 relation            :   '(' role_player ( ',' role_player )* ')' ;              // A list of role players in a Relations
-role_player         :   type ':' player                                         // The Role type and and player variable
-                    |            player ;                                       // Or just the player variable
+role_player         :   type_unscoped   ':' player                              // The Role type and and player variable
+                    |   player          ;                                       // Or just the player variable
 player              :   VAR_ ;                                                  // A player is just a variable
 // ATTRIBUTE CONSTRUCT =========================================================
 
 attributes          :   attribute ( ',' attribute )* ;
-attribute           :   HAS type_label ( VAR_ | operation ) ;                   // Attribute ownership by variable or a
+attribute           :   HAS type_label_unscoped ( VAR_ | operation ) ;          // Attribute ownership by variable or a
                                                                                 // predicate
 // ATTRIBUTE OPERATION CONSTRUCTS ==============================================
 
@@ -200,17 +200,17 @@ compute_arg         :   MIN_K     '=' INTEGER_                                  
 // TYPE, LABEL AND IDENTIFIER CONSTRUCTS =======================================
 
 // we have both scoped and unscoped types, both of which can just be vars
-type_ref            :   type                | type_scoped ;
-type_scoped         :   type_label_scoped   | VAR_        ;
-type                :   type_label          | VAR_        ;
+type                :   type_unscoped           | type_scoped ;
+type_scoped         :   type_label_scoped       | VAR_        ;
+type_unscoped       :   type_label_unscoped     | VAR_        ;
 
 
-type_label_ref      :   type_label      |  type_label_scoped  ;
-type_label_scoped   :   type_label     ':' type_label         ;
-type_label          :   type_native     |  type_name          | unreserved  ;
+type_label          :   type_label_unscoped     |  type_label_scoped    ;
+type_label_scoped   :   type_label_unscoped    ':' type_label_unscoped  ;
+type_label_unscoped :   type_native             |  type_name            | unreserved  ;
 
-type_labels         :   type_label      | type_label_array      ;
-type_label_array    :   '[' type_label ( ',' type_label )* ']'  ;
+type_labels         :   type_label_unscoped     | type_label_array                ;
+type_label_array    :   '[' type_label_unscoped ( ',' type_label_unscoped )* ']'  ;
 
 // LITERAL INPUT VALUES =======================================================
 

--- a/java/Graql.java
+++ b/java/Graql.java
@@ -28,6 +28,7 @@ import graql.lang.query.GraqlInsert;
 import graql.lang.query.GraqlQuery;
 import graql.lang.query.GraqlUndefine;
 import graql.lang.query.MatchClause;
+import graql.lang.statement.Label;
 import graql.lang.statement.Statement;
 import graql.lang.statement.StatementAttribute;
 import graql.lang.statement.StatementRelation;
@@ -247,13 +248,18 @@ public class Graql {
     }
 
     @CheckReturnValue
-    public static StatementType type(Graql.Token.Type type) {
-        return type(type.toString());
+    public static StatementType type(Label label) {
+        return hiddenVar().type(label);
     }
 
     @CheckReturnValue
     public static StatementType type(String label) {
         return hiddenVar().type(label);
+    }
+
+    @CheckReturnValue
+    public static StatementType type(String label, String scope) {
+        return hiddenVar().type(label, scope);
     }
 
     @CheckReturnValue

--- a/java/property/TypeProperty.java
+++ b/java/property/TypeProperty.java
@@ -18,6 +18,7 @@
 package graql.lang.property;
 
 import graql.lang.Graql;
+import graql.lang.statement.Label;
 import graql.lang.statement.StatementType;
 
 /**
@@ -27,17 +28,17 @@ import graql.lang.statement.StatementType;
  */
 public class TypeProperty extends VarProperty {
 
-    private final String name;
+    private final Label label;
 
-    public TypeProperty(String name) {
-        if (name == null) {
+    public TypeProperty(Label label) {
+        if (label == null) {
             throw new NullPointerException("Null label");
         }
-        this.name = name;
+        this.label = label;
     }
 
-    public String name() {
-        return name;
+    public Label label() {
+        return label;
     }
 
     @Override
@@ -47,7 +48,7 @@ public class TypeProperty extends VarProperty {
 
     @Override
     public String property() {
-        return name();
+        return label().toString();
     }
 
     @Override
@@ -72,7 +73,7 @@ public class TypeProperty extends VarProperty {
         }
         if (o instanceof TypeProperty) {
             TypeProperty that = (TypeProperty) o;
-            return (this.name.equals(that.name));
+            return (this.label.equals(that.label));
         }
         return false;
     }
@@ -81,7 +82,7 @@ public class TypeProperty extends VarProperty {
     public int hashCode() {
         int h = 1;
         h *= 1000003;
-        h ^= this.name.hashCode();
+        h ^= this.label.hashCode();
         return h;
     }
 }

--- a/java/query/GraqlCompute.java
+++ b/java/query/GraqlCompute.java
@@ -20,6 +20,7 @@ package graql.lang.query;
 import graql.lang.Graql;
 import graql.lang.exception.GraqlException;
 import graql.lang.query.builder.Computable;
+import graql.lang.statement.Label;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,8 +56,8 @@ public abstract class GraqlCompute extends GraqlQuery implements Computable {
     // they will be initialised when the user provides input
     String fromID = null;
     String toID = null;
-    Set<String> ofTypes = null;
-    Set<String> inTypes = null;
+    Set<Label> ofTypes = null;
+    Set<Label> inTypes = null;
     Graql.Token.Compute.Algorithm algorithm = null;
     Arguments arguments = null;
     // But 'arguments' will also be set when where() is called for cluster/centrality
@@ -72,7 +73,7 @@ public abstract class GraqlCompute extends GraqlQuery implements Computable {
     }
 
     @CheckReturnValue
-    public Set<String> in() {
+    public Set<Label> in() {
         if (this.inTypes == null) return set();
         return inTypes;
     }
@@ -127,7 +128,7 @@ public abstract class GraqlCompute extends GraqlQuery implements Computable {
         return "";
     }
 
-    private String printTypes(Set<String> types) {
+    private String printTypes(Set<Label> types) {
         StringBuilder inTypesString = new StringBuilder();
 
         if (!types.isEmpty()) {
@@ -135,7 +136,7 @@ public abstract class GraqlCompute extends GraqlQuery implements Computable {
                 inTypesString.append(types.iterator().next());
             } else {
                 inTypesString.append(Graql.Token.Char.SQUARE_OPEN);
-                inTypesString.append(inTypes.stream().collect(joining(Graql.Token.Char.COMMA_SPACE.toString())));
+                inTypesString.append(inTypes.stream().map(Label::toString).collect(joining(Graql.Token.Char.COMMA_SPACE.toString())));
                 inTypesString.append(Graql.Token.Char.SQUARE_CLOSE);
             }
         }
@@ -252,7 +253,7 @@ public abstract class GraqlCompute extends GraqlQuery implements Computable {
             }
 
             @Override
-            public GraqlCompute.Statistics.Count in(Collection<String> types) {
+            public GraqlCompute.Statistics.Count in(Collection<Label> types) {
                 this.inTypes = set(types);
                 return this;
             }
@@ -304,18 +305,18 @@ public abstract class GraqlCompute extends GraqlQuery implements Computable {
             }
 
             @CheckReturnValue
-            public final Set<String> of(){
+            public final Set<Label> of(){
                 return ofTypes == null ? set() : ofTypes;
             }
 
             @Override
-            public GraqlCompute.Statistics.Value of(Collection<String> types) {
+            public GraqlCompute.Statistics.Value of(Collection<Label> types) {
                 this.ofTypes = set(types);
                 return this;
             }
 
             @Override
-            public GraqlCompute.Statistics.Value in(Collection<String> types) {
+            public GraqlCompute.Statistics.Value in(Collection<Label> types) {
                 this.inTypes = set(types);
                 return this;
             }
@@ -398,7 +399,7 @@ public abstract class GraqlCompute extends GraqlQuery implements Computable {
         }
 
         @Override
-        public GraqlCompute.Path in(Collection<String> types) {
+        public GraqlCompute.Path in(Collection<Label> types) {
             this.inTypes = set(types);
             return this;
         }
@@ -484,7 +485,7 @@ public abstract class GraqlCompute extends GraqlQuery implements Computable {
         }
 
         @Override
-        public T in(Collection<String> types) {
+        public T in(Collection<Label> types) {
             this.inTypes = set(types);
             return self();
         }
@@ -547,12 +548,12 @@ public abstract class GraqlCompute extends GraqlQuery implements Computable {
         }
 
         @CheckReturnValue
-        public final Set<String> of(){
+        public final Set<Label> of(){
             return ofTypes == null ? set() : ofTypes;
         }
 
         @Override
-        public GraqlCompute.Centrality of(Collection<String> types) {
+        public GraqlCompute.Centrality of(Collection<Label> types) {
             this.ofTypes = set(types);
             return this;
         }

--- a/java/query/builder/Computable.java
+++ b/java/query/builder/Computable.java
@@ -19,6 +19,7 @@ package graql.lang.query.builder;
 
 import graql.lang.Graql;
 import graql.lang.exception.GraqlException;
+import graql.lang.statement.Label;
 
 import javax.annotation.CheckReturnValue;
 import java.util.ArrayList;
@@ -58,11 +59,24 @@ public interface Computable {
     interface Targetable<T extends Computable.Targetable> extends Computable {
 
         @CheckReturnValue
-        Set<String> of();
+        Set<Label> of();
 
+        /**
+         * Specify a list of unscoped types to use, as compute always uses unscoped targetable types
+         */
         @CheckReturnValue
         default T of(String type, String... types) {
-            ArrayList<String> typeList = new ArrayList<>(types.length + 1);
+            ArrayList<Label> typeList = new ArrayList<>(types.length + 1);
+            typeList.add(Label.of(type, null));
+            for (String t : types) {
+                typeList.add(Label.of(t, null));
+            }
+
+            return of(typeList);
+        }
+        @CheckReturnValue
+        default T of(Label type, Label... types) {
+            ArrayList<Label> typeList = new ArrayList<>(types.length + 1);
             typeList.add(type);
             typeList.addAll(Arrays.asList(types));
 
@@ -70,20 +84,34 @@ public interface Computable {
         }
 
         @CheckReturnValue
-        T of(Collection<String> types);
+        T of(Collection<Label> types);
     }
 
     interface Scopeable<T extends Computable.Scopeable> extends Computable {
 
         @CheckReturnValue
-        Set<String> in();
+        Set<Label> in();
 
         @CheckReturnValue
         boolean includesAttributes();
 
+        /**
+         * Specify an unscoped list of types to use, as compute always uses unscoped types
+         */
         @CheckReturnValue
         default T in(String type, String... types) {
-            ArrayList<String> typeList = new ArrayList<>(types.length + 1);
+            ArrayList<Label> typeList = new ArrayList<>(types.length + 1);
+            typeList.add(Label.of(type, null));
+            for (String t : types) {
+                typeList.add(Label.of(t, null));
+            }
+
+            return in(typeList);
+        }
+
+        @CheckReturnValue
+        default T in(Label type, Label... types) {
+            ArrayList<Label> typeList = new ArrayList<>(types.length + 1);
             typeList.add(type);
             typeList.addAll(Arrays.asList(types));
 
@@ -91,7 +119,7 @@ public interface Computable {
         }
 
         @CheckReturnValue
-        T in(Collection<String> types);
+        T in(Collection<Label> types);
 
         @CheckReturnValue
         T attributes(boolean include);

--- a/java/statement/Label.java
+++ b/java/statement/Label.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2020 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+package graql.lang.statement;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
+import java.io.Serializable;
+
+/**
+ * A Label is composed of a Name and an optional Scope
+ */
+public class Label implements Comparable<Label>, Serializable {
+    private static final long serialVersionUID = 2051578406740868932L;
+
+    private final String name;
+    private final String scope;
+    private final String scopedName;
+
+    public Label(String name, @Nullable String scope) {
+        if (name == null) {
+            throw new NullPointerException("Null value");
+        }
+        this.name = name;
+        this.scope = scope;
+        if (scope == null) {
+            scopedName = name;
+        } else {
+            scopedName = scope + ":" + name;
+        }
+    }
+
+    /**
+     * @param name The string which potentially represents a Type
+     * @return The matching Type Label
+     */
+    @CheckReturnValue
+    public static Label of(String name) {
+        return new Label(name, null);
+    }
+
+    /**
+     * @param name The string which potentially represents a Type
+     * @param scope The scope for this type
+     * @return The matching Type Label
+     */
+    @CheckReturnValue
+    public static Label of(String name, String scope) {
+        return new Label(name, scope);
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String scope() {
+        return scope;
+    }
+
+    public String scopedName() {
+        return scopedName;
+    }
+
+    @Override
+    public int compareTo(Label o) {
+        return scopedName.compareTo(o.scopedName());
+    }
+
+    @Override
+    public final String toString() {
+        return scopedName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o instanceof Label) {
+            Label that = (Label) o;
+            return (this.scopedName.equals(that.scopedName()));
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        int h = 1;
+        h *= 1000003;
+        h ^= this.scopedName.hashCode();
+        return h;
+    }
+}

--- a/java/statement/Statement.java
+++ b/java/statement/Statement.java
@@ -188,15 +188,15 @@ public class Statement implements Pattern,
      * @return the name this variable represents, if it represents something with a specific name
      */
     @CheckReturnValue
-    public Optional<String> getType() {
-        return getProperty(TypeProperty.class).map(TypeProperty::name);
+    public Optional<Label> getType() {
+        return getProperty(TypeProperty.class).map(TypeProperty::label);
     }
 
     /**
      * @return all type names that this variable refers to
      */
     @CheckReturnValue
-    public Set<String> getTypes() {
+    public Set<Label> getTypes() {
         return properties().stream()
                 .flatMap(VarProperty::types)
                 .map(Statement::getType)
@@ -276,9 +276,9 @@ public class Statement implements Pattern,
             return var().toString();
         } else if (properties().size() == 1) {
             // If there is only a label, we display that
-            Optional<String> label = getType();
+            Optional<Label> label = getType();
             if (label.isPresent()) {
-                return label.get();
+                return label.get().toString();
             }
         }
 

--- a/java/statement/builder/StatementTypeBuilder.java
+++ b/java/statement/builder/StatementTypeBuilder.java
@@ -30,6 +30,7 @@ import graql.lang.property.ThenProperty;
 import graql.lang.property.TypeProperty;
 import graql.lang.property.VarProperty;
 import graql.lang.property.WhenProperty;
+import graql.lang.statement.Label;
 import graql.lang.statement.Statement;
 import graql.lang.statement.StatementType;
 
@@ -46,72 +47,67 @@ public interface StatementTypeBuilder {
         return type(type.toString());
     }
     
-    /**
-     * @param name a string that this variable's label must match
-     * @return this
-     */
     @CheckReturnValue
-    default StatementType type(String name) {
-        return type(new TypeProperty(name));
+    default StatementType type(String label) {
+        return type(new TypeProperty(Label.of(label, null)));
     }
 
-    /**
-     * set this concept type variable as abstract, meaning it cannot have direct instances
-     *
-     * @return this
-     */
+    @CheckReturnValue
+    default StatementType type(String label, String scope) {
+        return type(new TypeProperty(Label.of(label, scope)));
+    }
+
+    @CheckReturnValue
+    default StatementType type(Label label) {
+        return type(new TypeProperty(label));
+    }
+
     @CheckReturnValue
     default StatementType isAbstract() {
         return type(AbstractProperty.get());
     }
 
     default StatementType sub(Graql.Token.Type type) {
-        return sub(type.toString());
+        return sub(type.toString(), null);
     }
 
-    /**
-     * @param type a concept type id that this variable must be a kind of
-     * @return this
-     */
+    @CheckReturnValue
+    default StatementType sub(String type, String scope) {
+        return sub(Graql.type(type, scope));
+    }
+
     @CheckReturnValue
     default StatementType sub(String type) {
         return sub(Graql.type(type));
     }
 
-    /**
-     * @param type a concept type that this variable must be a kind of
-     * @return this
-     */
     @CheckReturnValue
     default StatementType sub(Statement type) {
         return sub(new SubProperty(type));
     }
 
-    default StatementType subX(Graql.Token.Type type) {
-        return subX(type.toString());
-    }
-
-    /**
-     * @param type a concept type id that this variable must be a kind of, without looking at parent types
-     * @return this
-     */
-    @CheckReturnValue
-    default StatementType subX(String type) {
-        return subX(Graql.type(type));
-    }
-
-    /**
-     * @param type a concept type that this variable must be a kind of, without looking at parent type
-     * @return this
-     */
-    @CheckReturnValue
-    default StatementType subX(Statement type) {
-        return sub(new SubProperty(type, true));
-    }
-
     @CheckReturnValue
     default StatementType sub(SubProperty property) {
         return type(property);
+    }
+
+    default StatementType subX(Graql.Token.Type type) {
+        return subX(type.toString(), null);
+    }
+
+    @CheckReturnValue
+    default StatementType subX(String type, String scope) {
+        return subX(Graql.type(type, scope));
+    }
+
+    @CheckReturnValue
+    default StatementType subX(String type) {
+        return subX(Graql.type(type ));
+    }
+
+    @CheckReturnValue
+    default StatementType subX(Statement type) {
+        return sub(new SubProperty(type, true));
     }
 
     /**
@@ -138,7 +134,7 @@ public interface StatementTypeBuilder {
      */
     @CheckReturnValue
     default StatementType has(String type) {
-        return has(Graql.type(type));
+        return has(Graql.type(type, null));
     }
 
     /**
@@ -155,8 +151,11 @@ public interface StatementTypeBuilder {
      * @return this
      */
     @CheckReturnValue
-    default StatementType plays(String type) {
-        return plays(Graql.type(type));
+    default StatementType plays(String type, String scope) {
+        if (scope == null) {
+            throw new NullPointerException("Plays must specify a non-null scope");
+        }
+        return plays(Graql.type(type, scope));
     }
 
     /**
@@ -168,39 +167,24 @@ public interface StatementTypeBuilder {
         return type(new PlaysProperty(type, false));
     }
 
-    /**
-     * @param type a Role id that this relation type variable must have
-     * @return this
-     */
     @CheckReturnValue
     default StatementType relates(String type) {
         return relates(type, null);
     }
 
-    /**
-     * @param type a Role that this relation type variable must have
-     * @return this
-     */
+    @CheckReturnValue
+    default StatementType relates(String roleType, String superRoleType) {
+        return relates(Graql.type(roleType), superRoleType == null ?
+                null : Graql.type(superRoleType));
+    }
+
     @CheckReturnValue
     default StatementType relates(Statement type) {
         return relates(type, null);
     }
 
-    /**
-     * @param roleType a Role id that this relation type variable must have
-     * @return this
-     */
     @CheckReturnValue
-    default StatementType relates(String roleType, @Nullable String superRoleType) {
-        return relates(Graql.type(roleType), superRoleType == null ? null : Graql.type(superRoleType));
-    }
-
-    /**
-     * @param roleType a Role that this relation type variable must have
-     * @return this
-     */
-    @CheckReturnValue
-    default StatementType relates(Statement roleType, @Nullable Statement superRoleType) {
+    default StatementType relates(Statement roleType, Statement superRoleType) {
         return type(new RelatesProperty(roleType, superRoleType));
     }
 


### PR DESCRIPTION
## What is the goal of this PR?
Relax constraints on `plays` to be scoped or unscoped. This led to a change in the grammar where now `type` is either `type_unscoped` or `type_scoped`, and correspondingly `type_label` which corresponds to `type_label_unscoped` and `type_label_scoped`

## What are the changes implemented in this PR?
* Allow `plays` to take a `scoped` or `unscoped` type 
* Refactor the structure of the grammar to remove `type_ref`. The default `type` is now either an scoped OR unscoped type.