### PR TITLE
Remove unneeded dependency on gRPC

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,12 +34,6 @@ bazel_common()
 bazel_deps()
 bazel_toolchain()
 
-load("@graknlabs_dependencies//builder/grpc:deps.bzl", grpc_deps = "deps")
-grpc_deps()
-
-load("@stackb_rules_proto//java:deps.bzl", "java_grpc_compile")
-java_grpc_compile()
-
 load("@graknlabs_dependencies//builder/java:deps.bzl", java_deps = "deps")
 java_deps()
 load("@graknlabs_dependencies//library/maven:rules.bzl", "maven")

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,7 +21,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "952d552d18e98b8bab112154ed9bd12eee53d16f", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "be630b3a9eec86131ad5e645640fe999be10a24a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_common():


### PR DESCRIPTION
## What is the goal of this PR?

Previously, we had to load gRPC dependency in `WORKSPACE` only to get access to `@bazel_skylib` (a dependency `bazel-distribution` required). This PR removes the unneeded dependency by upgrading `@graknlabs_dependencies` where it's loaded from the same macro as `bazel-distributon` is.

## What are the changes implemented in this PR?

- Remove grpc from `WORKSPACE`
- Upgrade `@graknlabs_dependencies` to latest `master`