### PR TITLE
Add filegroup declaring CI targets

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -41,3 +41,15 @@ release_validate_deps(
     ],
     tags = ["manual"]  # in order for bazel test //... to not fail
 )
+
+# CI targets that are not declared in any BUILD file, but are called externally
+filegroup(
+    name = "ci",
+    data = [
+        "@graknlabs_dependencies//library/maven:update",
+        "@graknlabs_dependencies//tool/checkstyle:test-coverage",
+        "@graknlabs_dependencies//tool/release:create-notes",
+        "@graknlabs_dependencies//tool/sonarcloud:code-analysis",
+        "@graknlabs_dependencies//tool/unuseddeps:unused-deps",
+    ],
+)

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,7 +21,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "52f3161ec48fa207e814d27facffb2cf1ff50408", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "1c86421327bec68a83c3f88d728add07010f797a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_common():


### PR DESCRIPTION
## What is the goal of this PR?

We also add a new toplevel BUILD file declaration for all targets used in CI and elsewhere to ensure these targets are correct at build time. We also bump the client-java commit.