### PR TITLE
Fix disjunction normalisation - missing sub-pattern cases

### DIFF
--- a/java/pattern/Disjunction.java
+++ b/java/pattern/Disjunction.java
@@ -51,8 +51,9 @@ public class Disjunction<T extends Pattern> implements Pattern {
     public Disjunction<Conjunction<Conjunctable>> normalise() {
         if (normalised == null) {
             final List<Conjunction<Conjunctable>> conjunctions = patterns.stream().flatMap(p -> {
-                if (p.isConjunction()) return Stream.of(new Conjunction<>(list(p.asConjunctable())));
+                if (p.isVariable()) return Stream.of(new Conjunction<>(list(p.asConjunctable())));
                 else if (p.isConjunction()) return p.asConjunction().normalise().patterns().stream();
+                else if (p.isNegation()) return Stream.of(new Conjunction<>(list(p.asNegation().normalise().asConjunctable())));
                 else return p.asDisjunction().normalise().patterns().stream();
             }).collect(toList());
             normalised = new Disjunction<>(conjunctions);

--- a/java/pattern/Disjunction.java
+++ b/java/pattern/Disjunction.java
@@ -52,8 +52,7 @@ public class Disjunction<T extends Pattern> implements Pattern {
         if (normalised == null) {
             final List<Conjunction<Conjunctable>> conjunctions = patterns.stream().flatMap(p -> {
                 if (p.isVariable()) return Stream.of(new Conjunction<>(list(p.asConjunctable())));
-                else if (p.isNegation()) return Stream.of(new Conjunction<>(list(p.asNegation().normalise()
-                        .asConjunctable())));
+                else if (p.isNegation()) return Stream.of(new Conjunction<>(list(p.asNegation().normalise().asConjunctable())));
                 else if (p.isConjunction()) return p.asConjunction().normalise().patterns().stream();
                 else return p.asDisjunction().normalise().patterns().stream();
             }).collect(toList());

--- a/java/pattern/Disjunction.java
+++ b/java/pattern/Disjunction.java
@@ -52,8 +52,9 @@ public class Disjunction<T extends Pattern> implements Pattern {
         if (normalised == null) {
             final List<Conjunction<Conjunctable>> conjunctions = patterns.stream().flatMap(p -> {
                 if (p.isVariable()) return Stream.of(new Conjunction<>(list(p.asConjunctable())));
+                else if (p.isNegation()) return Stream.of(new Conjunction<>(list(p.asNegation().normalise()
+                        .asConjunctable())));
                 else if (p.isConjunction()) return p.asConjunction().normalise().patterns().stream();
-                else if (p.isNegation()) return Stream.of(new Conjunction<>(list(p.asNegation().normalise().asConjunctable())));
                 else return p.asDisjunction().normalise().patterns().stream();
             }).collect(toList());
             normalised = new Disjunction<>(conjunctions);

--- a/java/test/behaviour/graql/GraqlSteps.java
+++ b/java/test/behaviour/graql/GraqlSteps.java
@@ -22,6 +22,7 @@ import graql.lang.Graql;
 import graql.lang.query.GraqlDefine;
 import graql.lang.query.GraqlDelete;
 import graql.lang.query.GraqlInsert;
+import graql.lang.query.GraqlMatch;
 import graql.lang.query.GraqlQuery;
 import graql.lang.query.GraqlUndefine;
 import io.cucumber.java.en.Given;
@@ -55,12 +56,14 @@ public class GraqlSteps {
     public void graql_insert(final String query) {
         final GraqlInsert parsed = Graql.parseQuery(query);
         assertEquals(parsed, Graql.parseQuery(parsed.toString()));
+        parsed.match().ifPresent(match -> match.conjunction().normalise());
     }
 
     @Given("graql delete")
     public void graql_delete(final String query) {
         final GraqlDelete parsed = Graql.parseQuery(query);
         assertEquals(parsed, Graql.parseQuery(parsed.toString()));
+        parsed.match().conjunction().normalise();
     }
 
     @Given("for graql query")
@@ -69,6 +72,9 @@ public class GraqlSteps {
     public void graql_get(final String query) {
         final GraqlQuery parsed = Graql.parseQuery(query);
         assertEquals(parsed, Graql.parseQuery(parsed.toString()));
+        if (parsed instanceof GraqlMatch) {
+            parsed.asMatch().conjunction().normalise();
+        }
     }
 
     @Given("graql get throws")


### PR DESCRIPTION
## What is the goal of this PR?
Fix normalisation in Graql patterns - every match or insert pattern should be normalisable.

## What are the changes implemented in this PR?
* Add missing case of `pattern.isVariable()` and `pattern.isNegation()` when normalising disjunctions, which led to casting errors.
* Graql BDD steps always try to normalise queries when possible.