### PR TITLE
Add normalisation tests for Disjunction and Negated sub-query

### DIFF
--- a/java/pattern/test/BUILD
+++ b/java/pattern/test/BUILD
@@ -29,11 +29,9 @@ java_test(
         # Internal Package Dependencies
         "//java:graql",
         "//java/query",
-        "//java/common:common",
         "//java/pattern",
 
         # Internal Repository Dependencies
-        "@graknlabs_common//:common",
 
         # External dependencies
         "@maven//:com_google_code_findbugs_jsr305",

--- a/java/pattern/test/BUILD
+++ b/java/pattern/test/BUILD
@@ -23,8 +23,8 @@ load("@graknlabs_dependencies//distribution:deployment.bzl", "deployment")
 
 java_test(
     name = "normalisation",
-    srcs = ["Normalisation.java"],
-    test_class = "graql.lang.pattern.test.Normalisation",
+    srcs = ["NormalisationTest.java"],
+    test_class = "graql.lang.pattern.test.NormalisationTest",
     deps = [
         # Internal Package Dependencies
         "//java:graql",

--- a/java/pattern/test/BUILD
+++ b/java/pattern/test/BUILD
@@ -1,0 +1,50 @@
+#
+# Copyright (C) 2020 Grakn Labs
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+package(default_visibility = ["//visibility:public"])
+
+load("@graknlabs_bazel_distribution//maven:rules.bzl", "assemble_maven", "deploy_maven")
+load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+load("@graknlabs_dependencies//distribution:deployment.bzl", "deployment")
+
+java_test(
+    name = "normalisation",
+    srcs = ["Normalisation.java"],
+    test_class = "graql.lang.pattern.test.Normalisation",
+    deps = [
+        # Internal Package Dependencies
+        "//java:graql",
+        "//java/query",
+        "//java/common:common",
+        "//java/pattern",
+
+        # Internal Repository Dependencies
+        "@graknlabs_common//:common",
+
+        # External dependencies
+        "@maven//:com_google_code_findbugs_jsr305",
+    ],
+    tags = ["maven_coordinates=io.graql:graql-pattern:{pom_version}"],
+)
+
+checkstyle_test(
+    name = "checkstyle",
+    include = glob([
+        "*",
+    ]),
+    license_type = "agpl",
+)

--- a/java/pattern/test/BUILD
+++ b/java/pattern/test/BUILD
@@ -36,7 +36,6 @@ java_test(
         # External dependencies
         "@maven//:com_google_code_findbugs_jsr305",
     ],
-    tags = ["maven_coordinates=io.graql:graql-pattern:{pom_version}"],
 )
 
 checkstyle_test(

--- a/java/pattern/test/Normalisation.java
+++ b/java/pattern/test/Normalisation.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package graql.lang.pattern.test;
+
+import graql.lang.Graql;
+import graql.lang.pattern.Conjunctable;
+import graql.lang.pattern.Conjunction;
+import graql.lang.pattern.Disjunction;
+import graql.lang.pattern.Pattern;
+import graql.lang.query.GraqlMatch;
+import graql.lang.query.GraqlQuery;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class Normalisation {
+
+    @Test
+    public void disjunction() {
+        String query = "match $com isa company; {$com has name $n1; $n1 \"the-company\";} or {$com has name $n2; $n2 \"another-company\";};";
+        GraqlMatch graqlMatch = Graql.parseQuery(query).asMatch();
+        Disjunction<Conjunction<Conjunctable>> normalised = graqlMatch.conjunction().normalise();
+
+        List<Conjunction<Conjunctable>> disjunction = normalised.patterns();
+        assertTrue(disjunction.size() == 2);
+        Conjunction<? extends Pattern> partA = Graql.parsePattern("{ $com isa company; $com has name $n1; $n1 \"the-company\"; }").asConjunction();
+        Conjunction<? extends Pattern> partB = Graql.parsePattern("{ $com isa company; $com has name $n2; $n2 \"another-company\";}").asConjunction();
+        disjunction.get(0).variables().forEach(var -> {
+            assertEquals(partA.variables().filter(variable -> variable.equals(var)).count(), 1);
+        });
+        disjunction.get(1).variables().forEach(var -> {
+            assertEquals(partB.variables().filter(variable -> variable.equals(var)).count(), 1);
+        });
+    }
+
+    @Test
+    public void negatedDisjunction() {
+        String query = "match $com isa company; not { $com has name $n1; { $n1 \"the-company\"; } or { $n1 \"other-company\"; }; }; ";
+        GraqlMatch graqlMatch = Graql.parseQuery(query).asMatch();
+        Disjunction<Conjunction<Conjunctable>> normalised = graqlMatch.conjunction().normalise();
+
+        String expected = "match $com isa company; not { " +
+                "{ $com has name $n1; $n1 \"the-company\"; } or { $com has name $n1; $n1 \"other-company\"; }; };";
+        GraqlQuery expectedQuery = Graql.parseQuery(expected);
+        Disjunction<? extends Pattern> inner = expectedQuery.asMatch().conjunction().patterns().get(1).asNegation().pattern().asDisjunction();
+        assertEquals(expected, expectedQuery.toString().replace("\n", " "));
+    }
+}

--- a/java/pattern/test/NormalisationTest.java
+++ b/java/pattern/test/NormalisationTest.java
@@ -31,9 +31,8 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
-public class Normalisation {
+public class NormalisationTest {
 
     @Test
     public void disjunction() {

--- a/java/pattern/variable/ThingVariable.java
+++ b/java/pattern/variable/ThingVariable.java
@@ -121,7 +121,7 @@ public abstract class ThingVariable<T extends ThingVariable<T>> extends BoundVar
     @Override
     public final boolean equals(final Object o) {
         if (this == o) return true;
-        if (o == null || o.getClass().isAssignableFrom(ThingVariable.class)) return false;
+        if (o == null || !ThingVariable.class.isAssignableFrom(o.getClass())) return false;
         final ThingVariable<?> that = (ThingVariable<?>) o;
 
         return (this.reference.equals(that.reference) && this.constraints.equals(that.constraints));


### PR DESCRIPTION
## What is the goal of this PR?
Implement a basic pair of tests for normalisation of disjunctions and negated conjunctions of disjunctions. Also fix a casting error in the `.equals()` of `ThingVariable`.

## What are the changes implemented in this PR?
* Test normaliation of disjunction
* Test normalisation of negated conjunction of disjunctions
* Fix a casting error when checking for equality in `ThingVariable`