### PR TITLE
Fixed parsing of played-role overriding, and printing of overridden types

### DIFF
--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -627,7 +627,7 @@ public class Parser extends GraqlBaseVisitor {
                 final Either<String, UnboundVariable> overridden = constraint.AS() == null ? null : visitType(constraint.type(1));
                 type = type.constrain(new TypeConstraint.Owns(visitType(constraint.type(0)), overridden, constraint.IS_KEY() != null));
             } else if (constraint.PLAYS() != null) {
-                final Either<String, UnboundVariable> overridden = constraint.AS() == null ? null : visitType(constraint.type(1));
+                final Either<String, UnboundVariable> overridden = constraint.AS() == null ? null : visitType(constraint.type(0));
                 type = type.constrain(new TypeConstraint.Plays(visitType_scoped(constraint.type_scoped()), overridden));
             } else if (constraint.RELATES() != null) {
                 final Either<String, UnboundVariable> overridden = constraint.AS() == null ? null : visitType(constraint.type(1));

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -599,6 +599,66 @@ public class ParserTest {
     }
 
     @Test
+    public void whenParsingDefineQueryWithOwnsOverrides_ResultIsSameAsJavaGraql() {
+        final String query = "define\n" +
+                "triangle sub entity;\n" +
+                "triangle owns side-length;\n" +
+                "triangle-right-angled sub triangle;\n" +
+                "triangle-right-angled owns hypotenuse-length as side-length;";
+        final GraqlDefine parsed = Graql.parseQuery(query).asDefine();
+
+        final GraqlDefine expected = define(
+                type("triangle").sub("entity"),
+                type("triangle").owns("side-length"),
+                type("triangle-right-angled").sub("triangle"),
+                type("triangle-right-angled").owns("hypotenuse-length", "side-length")
+        );
+        assertQueryEquals(expected, parsed, query);
+    }
+
+    @Test
+    public void whenParsingDefineQueryWithRelatesOverrides_ResultIsSameAsJavaGraql() {
+        final String query = "define\n" +
+                "pokemon sub entity;\n" +
+                "evolves sub relation;\n" +
+                "evolves relates from, relates to;\n" +
+                "evolves-final sub evolves;\n" +
+                "evolves-final relates from-final as from;";
+        final GraqlDefine parsed = Graql.parseQuery(query).asDefine();
+
+        final GraqlDefine expected = define(
+                type("pokemon").sub("entity"),
+                type("evolves").sub("relation"),
+                type("evolves").relates("from").relates("to"),
+                type("evolves-final").sub("evolves"),
+                type("evolves-final").relates("from-final", "from")
+        );
+        assertQueryEquals(expected, parsed, query);
+    }
+
+    @Test
+    public void whenParsingDefineQueryWithPlaysOverrides_ResultIsSameAsJavaGraql() {
+        final String query = "define\n" +
+                "pokemon sub entity;\n" +
+                "evolves sub relation;\n" +
+                "evolves relates from, relates to;\n" +
+                "evolves-final sub evolves;\n" +
+                "evolves-final relates from-final as from;\n" +
+                "pokemon plays evolves-final:from-final as from;";
+        final GraqlDefine parsed = Graql.parseQuery(query).asDefine();
+
+        final GraqlDefine expected = define(
+                type("pokemon").sub("entity"),
+                type("evolves").sub("relation"),
+                type("evolves").relates("from").relates("to"),
+                type("evolves-final").sub("evolves"),
+                type("evolves-final").relates("from-final", "from"),
+                type("pokemon").plays("evolves-final", "from-final", "from")
+        );
+        assertQueryEquals(expected, parsed, query);
+    }
+
+    @Test
     public void whenParsingDefineQuery_ResultIsSameAsJavaGraql() {
         final String query = "define\n" +
                 "pokemon sub entity;\n" +

--- a/java/pattern/constraint/TypeConstraint.java
+++ b/java/pattern/constraint/TypeConstraint.java
@@ -466,22 +466,9 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
 
         @Override
         public String toString() {
-            StringBuilder syntax = new StringBuilder();
-            syntax.append(OWNS).append(SPACE);
-
-            if (!attributeType.label().isPresent()) syntax.append(attributeType);
-            else syntax.append(attributeType.label().get().label());
-
-            if (isKey) syntax.append(SPACE).append(IS_KEY);
-
-            if (overriddenAttributeType!=null) {
-                syntax.append(SPACE).append(AS).append(SPACE);
-
-                if (!overriddenAttributeType.label().isPresent()) syntax.append(overriddenAttributeType);
-                else syntax.append(overriddenAttributeType.label().get().label());
-            }
-
-            return syntax.toString();
+            return "" + OWNS + SPACE + attributeType +
+                    (overriddenAttributeType != null ? "" + SPACE + AS + SPACE + overriddenAttributeType : "") +
+                    (isKey ? "" + SPACE + IS_KEY : "");
         }
 
         @Override
@@ -577,24 +564,8 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
 
         @Override
         public String toString() {
-            StringBuilder syntax = new StringBuilder();
-
-            syntax.append(PLAYS).append(SPACE);
-            if (relationType!=null) {
-                if (!relationType.label().isPresent()) syntax.append(relationType);
-                else syntax.append(relationType.label().get().label());
-                syntax.append(COLON);
-            }
-
-            if (!roleType.label().isPresent()) syntax.append(roleType);
-            else syntax.append(roleType.label().get().label());
-
-            if (overriddenRoleType != null) {
-                syntax.append(SPACE).append(AS).append(SPACE);
-                if (!overriddenRoleType.label().isPresent()) syntax.append(overriddenRoleType);
-                else syntax.append(overriddenRoleType.label().get().label());
-            }
-            return syntax.toString();
+            return PLAYS.toString() + SPACE + roleType +
+                    (overriddenRoleType!=null ? "" + SPACE + AS + SPACE +  overriddenRoleType : "");
         }
 
         @Override

--- a/java/pattern/constraint/TypeConstraint.java
+++ b/java/pattern/constraint/TypeConstraint.java
@@ -466,7 +466,17 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
 
         @Override
         public String toString() {
-            return OWNS.toString() + SPACE + attributeType + (isKey ? "" + SPACE + IS_KEY : "");
+            StringBuilder syntax = new StringBuilder();
+            syntax.append(OWNS).append(SPACE);
+            if (!attributeType.label().isPresent()) syntax.append(attributeType);
+            else syntax.append(attributeType.label().get().label());
+            if (isKey) syntax.append(SPACE).append(IS_KEY);
+            if (overriddenAttributeType!=null) {
+                syntax.append(SPACE).append(AS).append(SPACE);
+                if (!overriddenAttributeType.label().isPresent()) syntax.append(overriddenAttributeType);
+                else syntax.append(overriddenAttributeType.label().get().label());
+            }
+            return syntax.toString();
         }
 
         @Override
@@ -562,7 +572,24 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
 
         @Override
         public String toString() {
-            return PLAYS.toString() + SPACE + roleType;
+            StringBuilder syntax = new StringBuilder();
+
+            syntax.append(PLAYS).append(SPACE);
+            if (relationType!=null) {
+                if (!relationType.label().isPresent()) syntax.append(relationType);
+                else syntax.append(relationType.label().get().label());
+                syntax.append(COLON);
+            }
+
+            if (!roleType.label().isPresent()) syntax.append(roleType);
+            else syntax.append(roleType.label().get().label());
+
+            if (overriddenRoleType != null) {
+                syntax.append(SPACE).append(AS).append(SPACE);
+                if (!overriddenRoleType.label().isPresent()) syntax.append(overriddenRoleType);
+                else syntax.append(overriddenRoleType.label().get().label());
+            }
+            return syntax.toString();
         }
 
         @Override

--- a/java/pattern/constraint/TypeConstraint.java
+++ b/java/pattern/constraint/TypeConstraint.java
@@ -468,14 +468,19 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
         public String toString() {
             StringBuilder syntax = new StringBuilder();
             syntax.append(OWNS).append(SPACE);
+
             if (!attributeType.label().isPresent()) syntax.append(attributeType);
             else syntax.append(attributeType.label().get().label());
+
             if (isKey) syntax.append(SPACE).append(IS_KEY);
+
             if (overriddenAttributeType!=null) {
                 syntax.append(SPACE).append(AS).append(SPACE);
+
                 if (!overriddenAttributeType.label().isPresent()) syntax.append(overriddenAttributeType);
                 else syntax.append(overriddenAttributeType.label().get().label());
             }
+
             return syntax.toString();
         }
 


### PR DESCRIPTION
## What is the goal of this PR?

Fix a bug whereby Graql would not parse overriding of roles and attributes, in patterns such as `$x owns age as biometric;` , `$r relates father as parent;` etc

## What are the changes implemented in this PR?

Parser was changed to correctly parse the overridden type. Three new tests were written in ParserTest to test overriding in relates, own and plays respectively. 

This exposed bugs in their respective toString method, which has now been fixed
