### PR TITLE
Upgrade @graknlabs_dependencies to fix dependency-analysis

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,7 +21,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "a4f56afaacd8d09cc62a6c2fc0fd55718eaa98c2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "ed2c074bea897dada26e4f112c1d08f739e90012", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_common():


### PR DESCRIPTION
## What is the goal of this PR?

Currently, `dependency-analysis` job has false-negative results which happened because of a bug in `@graknlabs_dependencies//grabl/analysis:dependency-analysis` (fixed in graknlabs/dependencies#233)

## What are the changes implemented in this PR?

Upgrade `@graknlabs_dependencies` to current latest `master`