### PR TITLE
Update artifacts.snapshot to fix build-dependency

### DIFF
--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -8,6 +8,8 @@
 @maven//:com_google_guava_guava_23_0
 @maven//:com_google_j2objc_j2objc_annotations
 @maven//:com_google_j2objc_j2objc_annotations_1_1
+@maven//:commons_io_commons_io
+@maven//:commons_io_commons_io_1_4
 @maven//:io_cucumber_cucumber_core
 @maven//:io_cucumber_cucumber_core_5_1_3
 @maven//:io_cucumber_cucumber_expressions
@@ -42,3 +44,5 @@
 @maven//:org_hamcrest_hamcrest_library_1_3
 @maven//:org_slf4j_slf4j_api
 @maven//:org_slf4j_slf4j_api_1_7_28
+@maven//:org_zeroturnaround_zt_exec
+@maven//:org_zeroturnaround_zt_exec_1_10


### PR DESCRIPTION
## What is the goal of this PR?

Fix `build-dependency` that's currently red in CI

## What are the changes implemented in this PR?

Fix `artifacts.snapshot` to be consistent with what Maven dependencies we depend on by running `dependencies/maven/update.sh`