### PR TITLE
Disable RBE

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -41,9 +41,9 @@ build:
     build:
       machine: graknlabs-ubuntu-20.04
       script: |
-        bazel build --config=rbe //... --test_output=errors
+        bazel build //... --test_output=errors
         bazel run @graknlabs_dependencies//tool/checkstyle:test-coverage
-        bazel test --config=rbe $(bazel query 'kind(checkstyle_test, //...)')
+        bazel test $(bazel query 'kind(checkstyle_test, //...)')
     build-dependency:
       machine: graknlabs-ubuntu-20.04
       script: |
@@ -53,7 +53,7 @@ build:
     test-graql-java:
       machine: graknlabs-ubuntu-20.04
       script: |
-        bazel test --config=rbe //java/... --test_output=errors
+        bazel test //java/... --test_output=errors
     deploy-maven-snapshot:
       filter:
         owner: graknlabs


### PR DESCRIPTION
## What is the goal of this PR?

Currently remote builds are returning 503 error, so we have to disable them for now.

## What are the changes implemented in this PR?

Replace all `--config=rbe` with blanks in CI config