### PR TITLE
Reference system refactor

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,7 +21,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "bec7e4103069a08384f32bc1d3bc8e17ff5f5af0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "b602038674e26cbdc9c0959e5e4de8938867e9b9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_common():

--- a/java/pattern/variable/Reference.java
+++ b/java/pattern/variable/Reference.java
@@ -32,7 +32,7 @@ public abstract class Reference {
     final Type type;
     final boolean isVisible;
 
-    public enum Type {NAME, LABEL, ANONYMOUS, SYSTEM}
+    protected enum Type {NAME, LABEL, ANONYMOUS, SYSTEM}
 
     Reference(Type type, boolean isVisible) {
         this.type = type;
@@ -61,7 +61,7 @@ public abstract class Reference {
         return isVisible;
     }
 
-    public boolean isReferrable() {
+    public boolean isReferable() {
         return !isAnonymous();
     }
 
@@ -77,8 +77,8 @@ public abstract class Reference {
         return type == Type.ANONYMOUS;
     }
 
-    public Reference.Referrable asReferrable() {
-        throw GraqlException.of(INVALID_CASTING.message(className(this.getClass()), className(Referrable.class)));
+    public Referable asReferable() {
+        throw GraqlException.of(INVALID_CASTING.message(className(this.getClass()), className(Referable.class)));
     }
 
     public Reference.Name asName() {
@@ -104,25 +104,25 @@ public abstract class Reference {
     @Override
     public abstract int hashCode();
 
-    public static abstract class Referrable extends Reference {
+    public static abstract class Referable extends Reference {
 
-        public Referrable(Type type, boolean isVisible) {
+        protected Referable(Type type, boolean isVisible) {
             super(type, isVisible);
         }
 
         @Override
-        public Reference.Referrable asReferrable() {
+        public Referable asReferable() {
             return this;
         }
     }
 
-    public static class Name extends Referrable {
+    public static class Name extends Referable {
 
         private static final Pattern REGEX = Pattern.compile("[a-zA-Z0-9][a-zA-Z0-9_-]*");
         protected final String name;
         private final int hash;
 
-        protected Name(String name) {
+        Name(String name) {
             super(Type.NAME, true);
             if (!REGEX.matcher(name).matches()) {
                 throw GraqlException.of(INVALID_VARIABLE_NAME.message(name, REGEX.toString()));
@@ -161,7 +161,7 @@ public abstract class Reference {
         }
     }
 
-    public static class Label extends Referrable {
+    public static class Label extends Referable {
 
         private final String label;
         private final int hash;

--- a/java/pattern/variable/Reference.java
+++ b/java/pattern/variable/Reference.java
@@ -32,7 +32,7 @@ public abstract class Reference {
     final Type type;
     final boolean isVisible;
 
-    enum Type {NAME, LABEL, ANONYMOUS}
+    public enum Type {NAME, LABEL, ANONYMOUS, SYSTEM}
 
     Reference(Type type, boolean isVisible) {
         this.type = type;
@@ -106,7 +106,7 @@ public abstract class Reference {
 
     public static abstract class Referrable extends Reference {
 
-        Referrable(Type type, boolean isVisible) {
+        public Referrable(Type type, boolean isVisible) {
             super(type, isVisible);
         }
 


### PR DESCRIPTION
## What is the goal of this PR?

* Adjust privacy of `Reference.Referable` and `Reference.Name` class for `Reference.System` refactor in Grakn.
* Fixed typos were "Referable" was misspelt as "Referrable".

## What are the changes implemented in this PR?

* Made `Reference.Referable` and `Reference.Type` constructor protected instead of package-private.
* Changed all "Referrable" to "Referable".
