### PR TITLE
Allow named unbound variables to be retrieved from insert & delete query

### DIFF
--- a/java/query/GraqlInsert.java
+++ b/java/query/GraqlInsert.java
@@ -39,7 +39,8 @@ public class GraqlInsert extends GraqlWritable {
 
     private static List<ThingVariable<?>> validVariables(@Nullable GraqlMatch.Unfiltered match, List<ThingVariable<?>> variables) {
         if (match != null) {
-            if (variables.stream().noneMatch(var -> var.isNamed() && match.namedVariablesUnbound().contains(var.toUnbound()) || var.variables().anyMatch(nestedVar -> match.namedVariablesUnbound().contains(nestedVar.toUnbound())))) {
+            if (variables.stream().noneMatch(var -> var.isNamed() && match.namedVariablesUnbound().contains(var.toUnbound())
+                    || var.variables().anyMatch(nestedVar -> match.namedVariablesUnbound().contains(nestedVar.toUnbound())))) {
                 throw GraqlException.of(INVALID_MATCH_INSERT_UNSCOPED.message(variables, match.namedVariablesUnbound()));
             }
         }


### PR DESCRIPTION
# What is the goal of this PR?

In order to correctly handle relationship insertion, insert queries need a method for retrieving all relevant variables from them.

## What are the changes implemented in this PR?

Implemented NamedUnboundVariables on GraqlInsert
