### PR TITLE
Reenable remote build caching

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,12 +22,9 @@ test --incompatible_strict_action_env
 # what is defined in this section will be applied when bazel is invoked like this: bazel ... --config=rbe ...
 build:rbe --project_id=grakn-dev
 build:rbe --remote_cache=cloud.buildbuddy.io
-build:rbe --remote_executor=cloud.buildbuddy.io
 build:rbe --bes_backend=cloud.buildbuddy.io
 build:rbe --bes_results_url=https://app.buildbuddy.io/invocation/
 build:rbe --tls_client_certificate=/opt/credentials/buildbuddy-cert.pem
 build:rbe --tls_client_key=/opt/credentials/buildbuddy-key.pem
-build:rbe --host_platform=@graknlabs_dependencies//image/buildbuddy:ubuntu-2004
-build:rbe --jobs=50
 build:rbe --remote_timeout=3600
 

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -41,9 +41,9 @@ build:
     build:
       image: graknlabs-ubuntu-20.04
       command: |
-        bazel build //... --test_output=errors
-        bazel run @graknlabs_dependencies//tool/checkstyle:test-coverage
-        bazel test $(bazel query 'kind(checkstyle_test, //...)')
+        bazel build --config=rbe //... --test_output=errors
+        bazel run --config=rbe @graknlabs_dependencies//tool/checkstyle:test-coverage
+        bazel test --config=rbe $(bazel query 'kind(checkstyle_test, //...)')
     build-dependency:
       image: graknlabs-ubuntu-20.04
       command: |
@@ -53,7 +53,7 @@ build:
     test-graql-java:
       image: graknlabs-ubuntu-20.04
       command: |
-        bazel test //java/... --test_output=errors
+        bazel test --config=rbe //java/... --test_output=errors
     deploy-maven-snapshot:
       filter:
         owner: graknlabs
@@ -63,12 +63,12 @@ build:
       command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
-        bazel run --define version=$(git rev-parse HEAD) //grammar:deploy-maven -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //java/common:deploy-maven -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //java/pattern:deploy-maven -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //java/query:deploy-maven -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //java/parser:deploy-maven -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //java:deploy-maven -- snapshot
+        bazel run --config=rbe --define version=$(git rev-parse HEAD) //grammar:deploy-maven -- snapshot
+        bazel run --config=rbe --define version=$(git rev-parse HEAD) //java/common:deploy-maven -- snapshot
+        bazel run --config=rbe --define version=$(git rev-parse HEAD) //java/pattern:deploy-maven -- snapshot
+        bazel run --config=rbe --define version=$(git rev-parse HEAD) //java/query:deploy-maven -- snapshot
+        bazel run --config=rbe --define version=$(git rev-parse HEAD) //java/parser:deploy-maven -- snapshot
+        bazel run --config=rbe --define version=$(git rev-parse HEAD) //java:deploy-maven -- snapshot
     test-deployment-maven:
       filter:
         owner: graknlabs
@@ -95,16 +95,16 @@ release:
         export RELEASE_NOTES_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @graknlabs_dependencies//tool/release:create-notes -- graql $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
+        bazel run --config=rbe --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
     deploy-maven-release:
       image: graknlabs-ubuntu-20.04
       dependencies: [deploy-github]
       command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
-        bazel run --define version=$(cat VERSION) //grammar:deploy-maven -- release
-        bazel run --define version=$(cat VERSION) //java/common:deploy-maven -- release
-        bazel run --define version=$(cat VERSION) //java/pattern:deploy-maven -- release
-        bazel run --define version=$(cat VERSION) //java/query:deploy-maven -- release
-        bazel run --define version=$(cat VERSION) //java/parser:deploy-maven -- release
-        bazel run --define version=$(cat VERSION) //java:deploy-maven -- release
+        bazel run --config=rbe --define version=$(cat VERSION) //grammar:deploy-maven -- release
+        bazel run --config=rbe --define version=$(cat VERSION) //java/common:deploy-maven -- release
+        bazel run --config=rbe --define version=$(cat VERSION) //java/pattern:deploy-maven -- release
+        bazel run --config=rbe --define version=$(cat VERSION) //java/query:deploy-maven -- release
+        bazel run --config=rbe --define version=$(cat VERSION) //java/parser:deploy-maven -- release
+        bazel run --config=rbe --define version=$(cat VERSION) //java:deploy-maven -- release


### PR DESCRIPTION
## What is the goal of this PR?

Speed up builds by utilizing remote caching provided by BuildBuddy.

## What are the changes implemented in this PR?

Reenable build caching (without remote execution) on all CI jobs