### PR TITLE
Add typeless has to thing variable builder

### DIFF
--- a/java/pattern/variable/builder/ThingVariableBuilder.java
+++ b/java/pattern/variable/builder/ThingVariableBuilder.java
@@ -90,6 +90,10 @@ public interface ThingVariableBuilder {
             return constrain(new ThingConstraint.Has(type, variable));
         }
 
+        default T has(UnboundVariable variable) {
+            return constrain(new ThingConstraint.Has(variable));
+        }
+
         T constrain(ThingConstraint.Isa constraint);
 
         T constrain(ThingConstraint.Has constraint);


### PR DESCRIPTION
## What is the goal of this PR?

As deleting a roleplayer now requires typeless has (to avoid a derived isa being present), we added a has overload to ThingVariableBuilder in order to construct a typeless has.

## What are the changes implemented in this PR?

Adds has with signature of `T has(UnboundVariable variable)` to ThingVariableBuilder
