### PR TITLE
Create GraqlMatch.Modifier to group filters

### DIFF
--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -45,7 +45,7 @@ query_delete_or_update:   MATCH       patterns      DELETE  variable_things
                                                   ( INSERT  variable_things )?  ;
 // TODO: The above feels like a hack. Find a clean way to split delete and update
 
-query_match           :   MATCH       patterns            ( modifiers )          ;
+query_match           :   MATCH       patterns            ( modifiers )         ;
 query_compute         :   COMPUTE     compute_conditions                        ;
 
 // MATCH QUERY ANSWER GROUP AND AGGREGATE FUNCTIONS ============================

--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -56,9 +56,9 @@ query_match_group_agg :   query_match   match_group       match_aggregate  ;
 
 // MATCH QUERY FILTERS =========================================================
 
-modifier              : ( get';' )? ( sort';' )? ( offset';' )? ( limit';' )?  ;
+modifier              : ( filter';' )? ( sort';' )? ( offset';' )? ( limit';' )?  ;
 
-get                   :   GET         VAR_  ( ',' VAR_ )*   ;
+filter                :   FILTER      VAR_  ( ',' VAR_ )*   ;
 sort                  :   SORT        VAR_        ORDER_?   ;
 offset                :   OFFSET      LONG_                 ;
 limit                 :   LIMIT       LONG_                 ;
@@ -251,7 +251,7 @@ unreserved            : VALUE
 
 // QUERY COMMAND KEYWORDS
 
-MATCH           : 'match'       ;   GET             : 'get'         ;
+MATCH           : 'match'       ;   FILTER             : 'get'         ;
 DEFINE          : 'define'      ;   UNDEFINE        : 'undefine'    ;
 INSERT          : 'insert'      ;   DELETE          : 'delete'      ;
 COMPUTE         : 'compute'     ;

--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -45,7 +45,7 @@ query_delete_or_update:   MATCH       patterns      DELETE  variable_things
                                                   ( INSERT  variable_things )?  ;
 // TODO: The above feels like a hack. Find a clean way to split delete and update
 
-query_match           :   MATCH       patterns            ( modifier )           ;
+query_match           :   MATCH       patterns            ( modifiers )          ;
 query_compute         :   COMPUTE     compute_conditions                        ;
 
 // MATCH QUERY ANSWER GROUP AND AGGREGATE FUNCTIONS ============================
@@ -56,7 +56,7 @@ query_match_group_agg :   query_match   match_group       match_aggregate  ;
 
 // MATCH QUERY FILTERS =========================================================
 
-modifier              : ( filter';' )? ( sort';' )? ( offset';' )? ( limit';' )?  ;
+modifiers             : ( filter';' )? ( sort';' )? ( offset';' )? ( limit';' )?  ;
 
 filter                :   FILTER      VAR_  ( ',' VAR_ )*   ;
 sort                  :   SORT        VAR_        ORDER_?   ;
@@ -251,7 +251,7 @@ unreserved            : VALUE
 
 // QUERY COMMAND KEYWORDS
 
-MATCH           : 'match'       ;   FILTER             : 'get'         ;
+MATCH           : 'match'       ;   FILTER          : 'get'         ;
 DEFINE          : 'define'      ;   UNDEFINE        : 'undefine'    ;
 INSERT          : 'insert'      ;   DELETE          : 'delete'      ;
 COMPUTE         : 'compute'     ;

--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -45,7 +45,7 @@ query_delete_or_update:   MATCH       patterns      DELETE  variable_things
                                                   ( INSERT  variable_things )?  ;
 // TODO: The above feels like a hack. Find a clean way to split delete and update
 
-query_match           :   MATCH       patterns            ( filters )           ;
+query_match           :   MATCH       patterns            ( modifier )           ;
 query_compute         :   COMPUTE     compute_conditions                        ;
 
 // MATCH QUERY ANSWER GROUP AND AGGREGATE FUNCTIONS ============================
@@ -56,7 +56,7 @@ query_match_group_agg :   query_match   match_group       match_aggregate  ;
 
 // MATCH QUERY FILTERS =========================================================
 
-filters               : ( get';' )? ( sort';' )? ( offset';' )? ( limit';' )?  ;
+modifier              : ( get';' )? ( sort';' )? ( offset';' )? ( limit';' )?  ;
 
 get                   :   GET         VAR_  ( ',' VAR_ )*   ;
 sort                  :   SORT        VAR_        ORDER_?   ;

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -307,20 +307,20 @@ public class Parser extends GraqlBaseVisitor {
     public GraqlMatch visitQuery_match(GraqlParser.Query_matchContext ctx) {
         GraqlMatch match = new GraqlMatch.Unfiltered(visitPatterns(ctx.patterns()));
 
-        if (ctx.modifier() != null) {
+        if (ctx.modifiers() != null) {
             List<UnboundVariable> variables = new ArrayList<>();
             Sortable.Sorting sorting = null;
             Long offset = null, limit = null;
 
-            if (ctx.modifier().filter() != null) variables = this.visitFilter(ctx.modifier().filter());
-            if (ctx.modifier().sort() != null) {
-                final UnboundVariable var = getVar(ctx.modifier().sort().VAR_());
-                sorting = ctx.modifier().sort().ORDER_() == null
+            if (ctx.modifiers().filter() != null) variables = this.visitFilter(ctx.modifiers().filter());
+            if (ctx.modifiers().sort() != null) {
+                final UnboundVariable var = getVar(ctx.modifiers().sort().VAR_());
+                sorting = ctx.modifiers().sort().ORDER_() == null
                         ? new Sortable.Sorting(var)
-                        : new Sortable.Sorting(var, GraqlArg.Order.of(ctx.modifier().sort().ORDER_().getText()));
+                        : new Sortable.Sorting(var, GraqlArg.Order.of(ctx.modifiers().sort().ORDER_().getText()));
             }
-            if (ctx.modifier().offset() != null) offset = getLong(ctx.modifier().offset().LONG_());
-            if (ctx.modifier().limit() != null) limit = getLong(ctx.modifier().limit().LONG_());
+            if (ctx.modifiers().offset() != null) offset = getLong(ctx.modifiers().offset().LONG_());
+            if (ctx.modifiers().limit() != null) limit = getLong(ctx.modifiers().limit().LONG_());
             match = new GraqlMatch(match.conjunction(), variables, sorting, offset, limit);
         }
 

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -312,7 +312,7 @@ public class Parser extends GraqlBaseVisitor {
             Sortable.Sorting sorting = null;
             Long offset = null, limit = null;
 
-            if (ctx.modifier().get() != null) variables = visitGet(ctx.modifier().get());
+            if (ctx.modifier().filter() != null) variables = this.visitFilter(ctx.modifier().filter());
             if (ctx.modifier().sort() != null) {
                 final UnboundVariable var = getVar(ctx.modifier().sort().VAR_());
                 sorting = ctx.modifier().sort().ORDER_() == null
@@ -364,7 +364,7 @@ public class Parser extends GraqlBaseVisitor {
     // GET QUERY MODIFIERS ==========================================
 
     @Override
-    public List<UnboundVariable> visitGet(GraqlParser.GetContext ctx) {
+    public List<UnboundVariable> visitFilter(GraqlParser.FilterContext ctx) {
         return ctx.VAR_().stream().map(this::getVar).collect(toList());
     }
 

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -307,20 +307,20 @@ public class Parser extends GraqlBaseVisitor {
     public GraqlMatch visitQuery_match(GraqlParser.Query_matchContext ctx) {
         GraqlMatch match = new GraqlMatch.Unfiltered(visitPatterns(ctx.patterns()));
 
-        if (ctx.filters() != null) {
+        if (ctx.modifier() != null) {
             List<UnboundVariable> variables = new ArrayList<>();
             Sortable.Sorting sorting = null;
             Long offset = null, limit = null;
 
-            if (ctx.filters().get() != null) variables = visitGet(ctx.filters().get());
-            if (ctx.filters().sort() != null) {
-                final UnboundVariable var = getVar(ctx.filters().sort().VAR_());
-                sorting = ctx.filters().sort().ORDER_() == null
+            if (ctx.modifier().get() != null) variables = visitGet(ctx.modifier().get());
+            if (ctx.modifier().sort() != null) {
+                final UnboundVariable var = getVar(ctx.modifier().sort().VAR_());
+                sorting = ctx.modifier().sort().ORDER_() == null
                         ? new Sortable.Sorting(var)
-                        : new Sortable.Sorting(var, GraqlArg.Order.of(ctx.filters().sort().ORDER_().getText()));
+                        : new Sortable.Sorting(var, GraqlArg.Order.of(ctx.modifier().sort().ORDER_().getText()));
             }
-            if (ctx.filters().offset() != null) offset = getLong(ctx.filters().offset().LONG_());
-            if (ctx.filters().limit() != null) limit = getLong(ctx.filters().limit().LONG_());
+            if (ctx.modifier().offset() != null) offset = getLong(ctx.modifier().offset().LONG_());
+            if (ctx.modifier().limit() != null) limit = getLong(ctx.modifier().limit().LONG_());
             match = new GraqlMatch(match.conjunction(), variables, sorting, offset, limit);
         }
 

--- a/java/query/GraqlMatch.java
+++ b/java/query/GraqlMatch.java
@@ -162,7 +162,7 @@ public class GraqlMatch extends GraqlQuery implements Aggregatable<GraqlMatch.Ag
         }
     }
 
-    public List<UnboundVariable> retrievedVars() {
+    private List<UnboundVariable> retrievedVars() {
         if (modifier.filter.isEmpty()) return variablesNamedUnbound;
         else return modifier.filter;
     }

--- a/java/query/GraqlMatch.java
+++ b/java/query/GraqlMatch.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import static grakn.common.collection.Collections.list;
@@ -115,6 +116,18 @@ public class GraqlMatch extends GraqlQuery implements Aggregatable<GraqlMatch.Ag
             return filter;
         }
 
+        public Optional<Long> offset() {
+            return Optional.ofNullable(offset);
+        }
+
+        public Optional<Long> limit() {
+            return Optional.ofNullable(limit);
+        }
+
+        public Optional<Sortable.Sorting> sort() {
+            return Optional.ofNullable(sorting);
+        }
+
         public boolean isEmpty() {
             return filter.isEmpty() && sorting == null && offset == null && limit == null;
         }
@@ -147,6 +160,11 @@ public class GraqlMatch extends GraqlQuery implements Aggregatable<GraqlMatch.Ag
         public int hashCode() {
             return hash;
         }
+    }
+
+    public List<UnboundVariable> retrievedVars() {
+        if (modifier.filter.isEmpty()) return variablesNamedUnbound;
+        else return modifier.filter;
     }
 
     private void hasBoundingConjunction() {
@@ -384,7 +402,7 @@ public class GraqlMatch extends GraqlQuery implements Aggregatable<GraqlMatch.Ag
                 throw new NullPointerException("Variable is null");
             } else if (var != null && method.equals(GraqlToken.Aggregate.Method.COUNT)) {
                 throw GraqlException.of(INVALID_COUNT_VARIABLE_ARGUMENT.message());
-            } else if (var != null && !query.modifier().filter().contains(var)) {
+            } else if (var != null && !query.retrievedVars().contains(var)) {
                 throw GraqlException.of(VARIABLE_OUT_OF_SCOPE_MATCH.message(var.toString()));
             }
 
@@ -450,7 +468,7 @@ public class GraqlMatch extends GraqlQuery implements Aggregatable<GraqlMatch.Ag
         Group(GraqlMatch query, UnboundVariable var) {
             if (query == null) throw new NullPointerException("GetQuery is null");
             if (var == null) throw new NullPointerException("Variable is null");
-            else if (!query.modifier().filter().contains(var)) {
+            else if (!query.retrievedVars().contains(var)) {
                 throw GraqlException.of(VARIABLE_OUT_OF_SCOPE_MATCH.message(var.toString()));
             }
 
@@ -517,7 +535,7 @@ public class GraqlMatch extends GraqlQuery implements Aggregatable<GraqlMatch.Ag
                     throw new NullPointerException("Variable is null");
                 } else if (var != null && method.equals(GraqlToken.Aggregate.Method.COUNT)) {
                     throw new IllegalArgumentException(INVALID_COUNT_VARIABLE_ARGUMENT.message());
-                } else if (var != null && !group.match().modifier().filter().contains(var)) {
+                } else if (var != null && !group.query.retrievedVars().contains(var)) {
                     throw GraqlException.of(VARIABLE_OUT_OF_SCOPE_MATCH.message(var.toString()));
                 }
 

--- a/java/query/GraqlMatch.java
+++ b/java/query/GraqlMatch.java
@@ -116,7 +116,7 @@ public class GraqlMatch extends GraqlQuery implements Aggregatable<GraqlMatch.Ag
         }
 
         public boolean isEmpty() {
-            return !filter.isEmpty() || sorting != null|| offset != null || limit != null;
+            return filter.isEmpty() && sorting == null && offset == null && limit == null;
         }
 
         @Override
@@ -168,8 +168,7 @@ public class GraqlMatch extends GraqlQuery implements Aggregatable<GraqlMatch.Ag
     private void filtersAreInScope() {
         Set<UnboundVariable> duplicates = new HashSet<>();
         for (UnboundVariable var : modifier.filter) {
-            if (!namedVariablesUnbound().contains(var))
-                throw GraqlException.of(VARIABLE_OUT_OF_SCOPE_MATCH.message(var));
+            if (!namedVariablesUnbound().contains(var)) throw GraqlException.of(VARIABLE_OUT_OF_SCOPE_MATCH.message(var));
             if (!var.isNamed()) throw GraqlException.of(VARIABLE_NOT_NAMED.message(var));
             if (duplicates.contains(var)) throw GraqlException.of(ILLEGAL_FILTER_VARIABLE_REPEATING);
             else duplicates.add(var);
@@ -242,7 +241,8 @@ public class GraqlMatch extends GraqlQuery implements Aggregatable<GraqlMatch.Ag
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true; if (o == null) return false;
+        if (this == o) return true;
+        if (o == null) return false;
         if (!getClass().isAssignableFrom(o.getClass()) && !o.getClass().isAssignableFrom(getClass())) {
             return false;
         }

--- a/java/query/GraqlMatch.java
+++ b/java/query/GraqlMatch.java
@@ -163,7 +163,7 @@ public class GraqlMatch extends GraqlQuery implements Aggregatable<GraqlMatch.Ag
     }
 
     private List<UnboundVariable> retrievedVars() {
-        if (modifier.filter.isEmpty()) return variablesNamedUnbound;
+        if (modifier.filter.isEmpty()) return namedVariablesUnbound();
         else return modifier.filter;
     }
 


### PR DESCRIPTION
## What is the goal of this PR?
To group together all the options available on a Match query, we create a `Modifier` object to hold `get` filter, and optional `limit`, `offset`, and `sort`

## What are the changes implemented in this PR?
Create `GraqlMatch.Modifier` inner class to hold onto the modifiers available on a match query.