### PR TITLE
Match modifier always returns non-empty filter

### DIFF
--- a/java/query/GraqlMatch.java
+++ b/java/query/GraqlMatch.java
@@ -162,7 +162,7 @@ public class GraqlMatch extends GraqlQuery implements Aggregatable<GraqlMatch.Ag
         }
     }
 
-    private List<UnboundVariable> retrievedVars() {
+    public List<UnboundVariable> retrievedVars() {
         if (modifiers.filter.isEmpty()) return namedVariablesUnbound();
         else return modifiers.filter;
     }

--- a/java/query/GraqlMatch.java
+++ b/java/query/GraqlMatch.java
@@ -94,7 +94,7 @@ public class GraqlMatch extends GraqlQuery implements Aggregatable<GraqlMatch.Ag
         this.hash = Objects.hash(this.conjunction, this.modifiers);
     }
 
-    public static class Modifiers {
+    public class Modifiers {
 
         private final List<UnboundVariable> filter;
         private final Sortable.Sorting sorting;
@@ -113,7 +113,8 @@ public class GraqlMatch extends GraqlQuery implements Aggregatable<GraqlMatch.Ag
         }
 
         public List<UnboundVariable> filter() {
-            return filter;
+            if (filter.isEmpty()) return namedVariablesUnbound();
+            else return filter;
         }
 
         public Optional<Long> offset() {
@@ -160,11 +161,6 @@ public class GraqlMatch extends GraqlQuery implements Aggregatable<GraqlMatch.Ag
         public int hashCode() {
             return hash;
         }
-    }
-
-    public List<UnboundVariable> retrievedVars() {
-        if (modifiers.filter.isEmpty()) return namedVariablesUnbound();
-        else return modifiers.filter;
     }
 
     private void hasBoundingConjunction() {
@@ -402,7 +398,7 @@ public class GraqlMatch extends GraqlQuery implements Aggregatable<GraqlMatch.Ag
                 throw new NullPointerException("Variable is null");
             } else if (var != null && method.equals(GraqlToken.Aggregate.Method.COUNT)) {
                 throw GraqlException.of(INVALID_COUNT_VARIABLE_ARGUMENT.message());
-            } else if (var != null && !query.retrievedVars().contains(var)) {
+            } else if (var != null && !query.modifiers.filter().contains(var)) {
                 throw GraqlException.of(VARIABLE_OUT_OF_SCOPE_MATCH.message(var.toString()));
             }
 
@@ -468,7 +464,7 @@ public class GraqlMatch extends GraqlQuery implements Aggregatable<GraqlMatch.Ag
         Group(GraqlMatch query, UnboundVariable var) {
             if (query == null) throw new NullPointerException("GetQuery is null");
             if (var == null) throw new NullPointerException("Variable is null");
-            else if (!query.retrievedVars().contains(var)) {
+            else if (!query.modifiers.filter().contains(var)) {
                 throw GraqlException.of(VARIABLE_OUT_OF_SCOPE_MATCH.message(var.toString()));
             }
 
@@ -535,7 +531,7 @@ public class GraqlMatch extends GraqlQuery implements Aggregatable<GraqlMatch.Ag
                     throw new NullPointerException("Variable is null");
                 } else if (var != null && method.equals(GraqlToken.Aggregate.Method.COUNT)) {
                     throw new IllegalArgumentException(INVALID_COUNT_VARIABLE_ARGUMENT.message());
-                } else if (var != null && !group.query.retrievedVars().contains(var)) {
+                } else if (var != null && !group.query.modifiers.filter().contains(var)) {
                     throw GraqlException.of(VARIABLE_OUT_OF_SCOPE_MATCH.message(var.toString()));
                 }
 


### PR DESCRIPTION
## What is the goal of this PR?

To avoid code duplication in core, we modify `Modifiers.filter()` to return the set of all named variables if no filter is present.

## What are the changes implemented in this PR?
* make `GraqlMatch.Modifiers` non-static
* always return non-empty list of filtered variables in `Modifiers.filter()`