### PR TITLE
Add Graql.parseLabel for label validation

### DIFF
--- a/grammar/Graql.g4
+++ b/grammar/Graql.g4
@@ -26,6 +26,7 @@ eof_pattern           :   pattern          EOF ;
 eof_patterns          :   patterns         EOF ;
 eof_definables        :   definables       EOF ;
 eof_variable          :   pattern_variable EOF ;
+eof_label             :   label            EOF ;
 eof_schema_rule       :   schema_rule      EOF ;
 
 // GRAQL QUERY LANGUAGE ========================================================

--- a/java/Graql.java
+++ b/java/Graql.java
@@ -18,6 +18,7 @@
 package graql.lang;
 
 import graql.lang.common.GraqlToken;
+import graql.lang.common.exception.GraqlException;
 import graql.lang.parser.Parser;
 import graql.lang.pattern.Conjunction;
 import graql.lang.pattern.Definable;
@@ -51,6 +52,8 @@ import static graql.lang.common.GraqlToken.Predicate.Equality.LTE;
 import static graql.lang.common.GraqlToken.Predicate.Equality.NEQ;
 import static graql.lang.common.GraqlToken.Predicate.SubString.CONTAINS;
 import static graql.lang.common.GraqlToken.Predicate.SubString.LIKE;
+import static graql.lang.common.exception.ErrorMessage.ILLEGAL_CHAR_IN_LABEL;
+import static graql.lang.common.exception.ErrorMessage.PARSED_LABEL_DIFFERS_FROM_RAW;
 import static graql.lang.pattern.variable.UnboundVariable.hidden;
 
 public class Graql {
@@ -82,7 +85,14 @@ public class Graql {
     }
 
     public static String parseLabel(String label) {
-        return parser.parseLabelEOF(label);
+        String parsedLabel;
+        try {
+            parsedLabel = parser.parseLabelEOF(label);
+        } catch (GraqlException e) {
+            throw GraqlException.of(ILLEGAL_CHAR_IN_LABEL.message(label));
+        }
+        if (!parsedLabel.equals(label)) throw GraqlException.of(PARSED_LABEL_DIFFERS_FROM_RAW.message(label, parsedLabel));
+        return parsedLabel;
     }
 
     public static GraqlMatch.Unfiltered match(Pattern... patterns) {

--- a/java/Graql.java
+++ b/java/Graql.java
@@ -53,7 +53,6 @@ import static graql.lang.common.GraqlToken.Predicate.Equality.NEQ;
 import static graql.lang.common.GraqlToken.Predicate.SubString.CONTAINS;
 import static graql.lang.common.GraqlToken.Predicate.SubString.LIKE;
 import static graql.lang.common.exception.ErrorMessage.ILLEGAL_CHAR_IN_LABEL;
-import static graql.lang.common.exception.ErrorMessage.PARSED_LABEL_DIFFERS_FROM_RAW;
 import static graql.lang.pattern.variable.UnboundVariable.hidden;
 
 public class Graql {
@@ -91,7 +90,7 @@ public class Graql {
         } catch (GraqlException e) {
             throw GraqlException.of(ILLEGAL_CHAR_IN_LABEL.message(label));
         }
-        if (!parsedLabel.equals(label)) throw GraqlException.of(PARSED_LABEL_DIFFERS_FROM_RAW.message(label, parsedLabel));
+        if (!parsedLabel.equals(label)) throw GraqlException.of(ILLEGAL_CHAR_IN_LABEL.message(label)); // e.g: 'abc#123'
         return parsedLabel;
     }
 

--- a/java/Graql.java
+++ b/java/Graql.java
@@ -81,6 +81,10 @@ public class Graql {
         return parser.parseVariableEOF(variable);
     }
 
+    public static String parseLabel(String label) {
+        return parser.parseLabelEOF(label);
+    }
+
     public static GraqlMatch.Unfiltered match(Pattern... patterns) {
         return match(Arrays.asList(patterns));
     }

--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -97,8 +97,6 @@ public class ErrorMessage extends grakn.common.exception.ErrorMessage {
             new ErrorMessage(38, "Illegal grammar!");
     public static final ErrorMessage ILLEGAL_CHAR_IN_LABEL =
             new ErrorMessage(39, "'%s' is not a valid Type label. Type labels must start with a letter, and may contain only letters, numbers, '-' and '_'.");
-    public static final ErrorMessage PARSED_LABEL_DIFFERS_FROM_RAW =
-            new ErrorMessage(40, "'%s' is not a valid Type label, because it mutates when parsed. The parsed value is '%s'.");
 
 
     private static final String codePrefix = "GQL";

--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -32,69 +32,73 @@ public class ErrorMessage extends grakn.common.exception.ErrorMessage {
     public static final ErrorMessage MISSING_DEFINABLES =
             new ErrorMessage(6, "The query has not been provided with any definables.");
     public static final ErrorMessage MATCH_HAS_NO_BOUNDING_NAMED_VARIABLE =
-            new ErrorMessage(37, "The match query does not have named variables to bound the nested disjunction/negation pattern(s).");
+            new ErrorMessage(7, "The match query does not have named variables to bound the nested disjunction/negation pattern(s).");
     public static final ErrorMessage MATCH_HAS_NO_NAMED_VARIABLE =
-            new ErrorMessage(7, "The match query has no named variables to retrieve.");
+            new ErrorMessage(8, "The match query has no named variables to retrieve.");
     public static final ErrorMessage MATCH_HAS_UNBOUNDED_NESTED_PATTERN =
-            new ErrorMessage(38, "The match query contains a nested pattern is not bounded: '%s'.");
+            new ErrorMessage(9, "The match query contains a nested pattern is not bounded: '%s'.");
     public static final ErrorMessage MISSING_MATCH_FILTER =
-            new ErrorMessage(8, "The match query cannot be constructed with NULL filter variable collection.");
+            new ErrorMessage(10, "The match query cannot be constructed with NULL filter variable collection.");
     public static final ErrorMessage EMPTY_MATCH_FILTER =
-            new ErrorMessage(9, "The match query cannot be filtered with an empty list of variables.");
+            new ErrorMessage(11, "The match query cannot be filtered with an empty list of variables.");
     public static final ErrorMessage INVALID_IID_STRING =
-            new ErrorMessage(10, "Invalid IID: '%s'. IIDs must follow the regular expression: '%s'.");
+            new ErrorMessage(12, "Invalid IID: '%s'. IIDs must follow the regular expression: '%s'.");
     public static final ErrorMessage INVALID_ATTRIBUTE_TYPE_REGEX =
-            new ErrorMessage(11, "Invalid regular expression '%s'.");
+            new ErrorMessage(13, "Invalid regular expression '%s'.");
     public static final ErrorMessage ILLEGAL_FILTER_VARIABLE_REPEATING =
-            new ErrorMessage(12, "The variable '%s' occurred more than once in match query filter.");
+            new ErrorMessage(14, "The variable '%s' occurred more than once in match query filter.");
     public static final ErrorMessage VARIABLE_OUT_OF_SCOPE_MATCH =
-            new ErrorMessage(13, "The variable '%s' is out of scope of the match query.");
+            new ErrorMessage(15, "The variable '%s' is out of scope of the match query.");
     public static final ErrorMessage VARIABLE_OUT_OF_SCOPE_DELETE =
-            new ErrorMessage(14, "The deleted variable '%s' is out of scope of the match query.");
+            new ErrorMessage(16, "The deleted variable '%s' is out of scope of the match query.");
     public static final ErrorMessage NO_VARIABLE_IN_SCOPE_INSERT =
-            new ErrorMessage(15, "None of the variables in 'insert' ('%s') is within scope of 'match' ('%s')");
+            new ErrorMessage(17, "None of the variables in 'insert' ('%s') is within scope of 'match' ('%s')");
     public static final ErrorMessage VARIABLE_NOT_NAMED =
-            new ErrorMessage(16, "The variable '%s' is not named and cannot be used as a filter for match query.");
+            new ErrorMessage(18, "The variable '%s' is not named and cannot be used as a filter for match query.");
     public static final ErrorMessage INVALID_VARIABLE_NAME =
-            new ErrorMessage(17, "The variable name '%s' is invalid; variables must match the following regular expression: '%s'.");
+            new ErrorMessage(19, "The variable name '%s' is invalid; variables must match the following regular expression: '%s'.");
     public static final ErrorMessage ILLEGAL_CONSTRAINT_REPETITION =
-            new ErrorMessage(18, "The variable '%s' contains illegally repeating constraints: '%s' and '%s'.");
+            new ErrorMessage(20, "The variable '%s' contains illegally repeating constraints: '%s' and '%s'.");
     public static final ErrorMessage MISSING_CONSTRAINT_RELATION_PLAYER =
-            new ErrorMessage(19, "A relation variable has not been provided with role players.");
+            new ErrorMessage(21, "A relation variable has not been provided with role players.");
     public static final ErrorMessage MISSING_CONSTRAINT_VALUE =
-            new ErrorMessage(20, "A value constraint has not been provided with a variable or literal value.");
+            new ErrorMessage(22, "A value constraint has not been provided with a variable or literal value.");
     public static final ErrorMessage MISSING_CONSTRAINT_PREDICATE =
-            new ErrorMessage(21, "A value constraint has not been provided with a predicate.");
+            new ErrorMessage(23, "A value constraint has not been provided with a predicate.");
     public static final ErrorMessage INVALID_CONSTRAINT_DATETIME_PRECISION =
-            new ErrorMessage(22, "Attempted to assign DateTime value of '%s' which is more precise than 1 millisecond.");
+            new ErrorMessage(24, "Attempted to assign DateTime value of '%s' which is more precise than 1 millisecond.");
     public static final ErrorMessage INVALID_DEFINE_QUERY_VARIABLE =
-            new ErrorMessage(23, "Invalid define/undefine query. User defined variables are not accepted in define/undefine query.");
+            new ErrorMessage(25, "Invalid define/undefine query. User defined variables are not accepted in define/undefine query.");
     public static final ErrorMessage INVALID_RULE_WHEN_MISSING_PATTERNS =
-            new ErrorMessage(24, "Rule '%s' 'when' has not been provided with any patterns.");
+            new ErrorMessage(26, "Rule '%s' 'when' has not been provided with any patterns.");
     public static final ErrorMessage INVALID_RULE_WHEN_NESTED_NEGATION =
-            new ErrorMessage(25, "Rule '%s' 'when' contains a nested negation.");
+            new ErrorMessage(27, "Rule '%s' 'when' contains a nested negation.");
     public static final ErrorMessage INVALID_RULE_WHEN_CONTAINS_DISJUNCTION =
-            new ErrorMessage(26, "Rule '%s' 'when' contains a disjunction.");
+            new ErrorMessage(28, "Rule '%s' 'when' contains a disjunction.");
     public static final ErrorMessage INVALID_RULE_THEN =
-            new ErrorMessage(27, "Rule '%s' 'then' '%s': must be exactly one attribute ownership, or exactly one relation.");
+            new ErrorMessage(29, "Rule '%s' 'then' '%s': must be exactly one attribute ownership, or exactly one relation.");
     public static final ErrorMessage INVALID_RULE_THEN_HAS =
-            new ErrorMessage(28, "Rule '%s' 'then' '%s': is trying to assign both an attribute type and a variable attribute value.");
+            new ErrorMessage(30, "Rule '%s' 'then' '%s': is trying to assign both an attribute type and a variable attribute value.");
     public static final ErrorMessage INVALID_RULE_THEN_VARIABLES =
-            new ErrorMessage(29, "Rule '%s' 'then' variables must be present in rule 'when'.");
+            new ErrorMessage(31, "Rule '%s' 'then' variables must be present in rule 'when'.");
     public static final ErrorMessage REDUNDANT_NESTED_NEGATION =
-            new ErrorMessage(30, "Invalid query containing redundant nested negations.");
+            new ErrorMessage(32, "Invalid query containing redundant nested negations.");
     public static final ErrorMessage MISSING_COMPUTE_CONDITION =
-            new ErrorMessage(31, "Missing condition(s) for 'compute '%s''. The required condition(s) are: '%s'.");
+            new ErrorMessage(33, "Missing condition(s) for 'compute '%s''. The required condition(s) are: '%s'.");
     public static final ErrorMessage INVALID_COMPUTE_METHOD_ALGORITHM =
-            new ErrorMessage(32, "Invalid algorithm for 'compute '%s''. The accepted algorithm(s) are: '%s'.");
+            new ErrorMessage(34, "Invalid algorithm for 'compute '%s''. The accepted algorithm(s) are: '%s'.");
     public static final ErrorMessage INVALID_COMPUTE_ARGUMENT =
-            new ErrorMessage(33, "Invalid argument(s) 'compute %s using %s'. The accepted argument(s) are: '%s'.");
+            new ErrorMessage(35, "Invalid argument(s) 'compute %s using %s'. The accepted argument(s) are: '%s'.");
     public static final ErrorMessage INVALID_SORTING_ORDER =
-            new ErrorMessage(34, "Invalid sorting order. Valid options: '%s' or '%s'.");
+            new ErrorMessage(36, "Invalid sorting order. Valid options: '%s' or '%s'.");
     public static final ErrorMessage INVALID_COUNT_VARIABLE_ARGUMENT =
-            new ErrorMessage(35, "Aggregate COUNT does not accept a Variable.");
+            new ErrorMessage(37, "Aggregate COUNT does not accept a Variable.");
     public static final ErrorMessage ILLEGAL_GRAMMAR =
-            new ErrorMessage(36, "Illegal grammar!");
+            new ErrorMessage(38, "Illegal grammar!");
+    public static final ErrorMessage ILLEGAL_CHAR_IN_LABEL =
+            new ErrorMessage(39, "'%s' is not a valid Type label. Type labels must start with a letter, and may contain only letters, numbers, '-' and '_'.");
+    public static final ErrorMessage PARSED_LABEL_DIFFERS_FROM_RAW =
+            new ErrorMessage(40, "'%s' is not a valid Type label, because it mutates when parsed. The parsed value is '%s'.");
 
 
     private static final String codePrefix = "GQL";

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -168,6 +168,10 @@ public class Parser extends GraqlBaseVisitor {
         return parse(variableString, GraqlParser::eof_variable, this::visitEof_variable);
     }
 
+    public String parseLabelEOF(String labelString) {
+        return parse(labelString, GraqlParser::eof_label, this::visitEof_label);
+    }
+
     public Definable parseSchemaRuleEOF(String ruleString) {
         return parse(ruleString, GraqlParser::eof_schema_rule, this::visitEof_schema_rule);
     }
@@ -215,6 +219,11 @@ public class Parser extends GraqlBaseVisitor {
     @Override
     public BoundVariable visitEof_variable(GraqlParser.Eof_variableContext ctx) {
         return visitPattern_variable(ctx.pattern_variable());
+    }
+
+    @Override
+    public String visitEof_label(GraqlParser.Eof_labelContext ctx) {
+        return ctx.label().getText();
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?

Because Graql type label validation is complex, we've introduced a method `Graql.parseLabel` that can be used to validate that a String is a valid type label.

## What are the changes implemented in this PR?

Add Graql.parseLabel
